### PR TITLE
docs: clarify repo topology and connected surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Opt-in community automation commons for SourceOS: CI/CD, update automation, trai
   - mandatory dependency of SourceOS
   - public docs site
   - canonical typed-contract registry
-- **Semantic direction:** this repo should eventually publish an automation-focused repo descriptor that references the shared SourceOS/SociOS vocabulary from `sourceos-spec`.
+- **Semantic direction:** this repo should eventually publish an automation-focused repo descriptor that references the shared SourceOS/SociOS vocabulary from `SourceOS-Linux/sourceos-spec`.
 
 ## socios in the SourceOS ecosystem (opt-in)
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,23 @@ Opt-in community automation commons for SourceOS: CI/CD, update automation, trai
 
 ---
 
+## Topology position
+
+- **Role:** opt-in community automation commons for SourceOS.
+- **Connects to:**
+  - `SociOS-Linux/SourceOS` — immutable substrate that must remain able to operate without socios
+  - `SociOS-Linux/agentos-spine` — Linux-side integration/workspace spine that can route or reference socios as an optional layer
+  - `SourceOS-Linux/sourceos-spec` — canonical typed contracts, JSON-LD contexts, and shared vocabulary
+  - `SociOS-Linux/workstation-contracts` — workstation/CI contract and conformance lane
+  - `SocioProphet/sociosphere` — platform workspace controller that may coordinate broader multi-repo automation lanes
+  - `SociOS-Linux/socioslinux-web` — public docs surface that explains the commons layer downstream
+- **Not this repo:**
+  - base OS substrate
+  - mandatory dependency of SourceOS
+  - public docs site
+  - canonical typed-contract registry
+- **Semantic direction:** this repo should eventually publish an automation-focused repo descriptor that references the shared SourceOS/SociOS vocabulary from `sourceos-spec`.
+
 ## socios in the SourceOS ecosystem (opt-in)
 
 **socios** is the *opt-in* community automated agentic build + commons layer for **SourceOS**:

--- a/semantic/repo.jsonld
+++ b/semantic/repo.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": "https://raw.githubusercontent.com/SourceOS-Linux/sourceos-spec/main/semantic/context.jsonld",
+  "@id": "urn:sourceos:repo:SociOS-Linux:socios",
+  "@type": ["RepoDescriptor", "Repository"],
+  "name": "socios",
+  "description": "Opt-in community automation commons for SourceOS.",
+  "repositoryFullName": "SociOS-Linux/socios",
+  "repoUrl": "https://github.com/SociOS-Linux/socios",
+  "organization": "SociOS-Linux",
+  "defaultBranch": "main",
+  "semanticDescriptorVersion": "0.1.0",
+  "topologyRole": "roleAutomationCommons",
+  "connectsTo": [
+    "urn:sourceos:repo:SociOS-Linux:SourceOS",
+    "urn:sourceos:repo:SociOS-Linux:agentos-spine",
+    "urn:sourceos:repo:SourceOS-Linux:sourceos-spec",
+    "urn:sourceos:repo:SociOS-Linux:workstation-contracts",
+    "urn:sourceos:repo:SocioProphet:sociosphere",
+    "urn:sourceos:repo:SociOS-Linux:socioslinux-web"
+  ],
+  "optionalLayerFor": [
+    "urn:sourceos:repo:SociOS-Linux:SourceOS"
+  ],
+  "consumesVocabularyFrom": "urn:sourceos:repo:SourceOS-Linux:sourceos-spec",
+  "notThisRepo": [
+    "base OS substrate",
+    "mandatory dependency of SourceOS",
+    "public docs site",
+    "canonical typed-contract registry"
+  ]
+}


### PR DESCRIPTION
## Summary

Clarifies that `socios` is the opt-in automation commons for SourceOS and not a required dependency of the substrate.

## Why

This repo is central to the commons/automation story, but its boundaries relative to SourceOS, the Linux spine, and the typed-contract lane need to be explicit on the landing page.
