### PR TITLE
Draft: add Fog opt-in automation role note

### DIFF
--- a/catalogs/fog/README.md
+++ b/catalogs/fog/README.md
@@ -1,0 +1,15 @@
+# Fog catalogs
+
+This directory is the placeholder home for signed fog-related catalogs once a node is explicitly enrolled into `socios`.
+
+## Intended catalog items
+
+- local-storage / CSI chart pins
+- fog agent image pins
+- ignition profile references
+- installer profile references
+- conformance policy pack references
+
+## Boundary
+
+These catalogs are **optional** and must never become a hidden dependency for local substrate correctness.

--- a/catalogs/fog/fog-replicator.yaml
+++ b/catalogs/fog/fog-replicator.yaml
@@ -1,0 +1,15 @@
+# Placeholder fog catalog entry for the topic replication agent.
+apiVersion: socios.dev/v1alpha1
+kind: FogCatalogEntry
+metadata:
+  name: fog-replicator
+spec:
+  category: agent-runtime
+  source:
+    kind: image
+    ref: ghcr.io/socioprophet/fog-replicator
+  version: 0.0.0-placeholder
+  digest: sha256:REPLACE_ME
+  notes:
+    - Replace with a digest-pinned image reference before use.
+    - Intended to replicate Hypercore topic state across enrolled nodes.

--- a/catalogs/fog/fog-worker.yaml
+++ b/catalogs/fog/fog-worker.yaml
@@ -1,0 +1,15 @@
+# Placeholder fog catalog entry for the compute worker agent.
+apiVersion: socios.dev/v1alpha1
+kind: FogCatalogEntry
+metadata:
+  name: fog-worker
+spec:
+  category: agent-runtime
+  source:
+    kind: image
+    ref: ghcr.io/socioprophet/fog-worker
+  version: 0.0.0-placeholder
+  digest: sha256:REPLACE_ME
+  notes:
+    - Replace with a digest-pinned image reference before use.
+    - Intended to execute FogCompute work orders and emit usage receipts.

--- a/catalogs/fog/topolvm.yaml
+++ b/catalogs/fog/topolvm.yaml
@@ -1,0 +1,14 @@
+# Placeholder fog catalog entry for local-storage / TopoLVM lane.
+apiVersion: socios.dev/v1alpha1
+kind: FogCatalogEntry
+metadata:
+  name: topolvm
+spec:
+  category: local-storage
+  source:
+    kind: helm
+    ref: topolvm/topolvm
+  version: 0.0.0-placeholder
+  digest: sha256:REPLACE_ME
+  notes:
+    - Replace with digest-pinned chart or artifact reference before use.

--- a/docs/FOG_ENROLLMENT.md
+++ b/docs/FOG_ENROLLMENT.md
@@ -1,0 +1,34 @@
+# Fog enrollment in socios
+
+This document clarifies how a fog-capable node may participate in the optional `socios` automation commons.
+
+## Non-default posture
+
+Enrollment is **off by default**.
+A fog-capable SourceOS node must be able to boot, mount its fog substrate, run local workloads, and participate in topic replication without `socios`.
+
+## What enrollment enables
+
+Once a node is explicitly enrolled, `socios` may provide:
+- signed artifact catalogs
+- rollout and update automation
+- policy-checked artifact admission
+- optional benchmark / training / test workflows
+
+## Minimum enrollment requirements
+
+A future concrete enrollment flow should require at least:
+- explicit user intent
+- a local proof-of-life or equivalent signed confirmation
+- review of the catalogs or update class being admitted
+- the ability to opt out and return to local-only operation
+
+## Fog-specific enrollment classes
+
+Potential classes include:
+- storage-only participant
+- topic replication participant
+- compute worker participant
+- benchmark/test-only participant
+
+These classes should be independently selectable rather than forced as one bundle.

--- a/docs/FOG_OPT_IN_AUTOMATION.md
+++ b/docs/FOG_OPT_IN_AUTOMATION.md
@@ -1,0 +1,61 @@
+# Fog Opt-In Automation Role in socios
+
+This document captures the intended **opt-in automation and catalog role** of `socios` for the Fog layer.
+
+The Fog layer must function without `socios`.
+
+`SociOS-Linux/socios` is the **optional commons / automation plane** that can distribute, validate, catalog, and update fog-related artifacts once a node is explicitly enrolled.
+
+## Non-negotiable posture
+
+- no SourceOS device is enrolled by default
+- no fog node requires `socios` to boot or function locally
+- any mutation requires explicit, user-signed intent
+- community artifacts must be digest-pinned and verifiable
+
+## What belongs here for the Fog layer
+
+### 1. Signed catalogs
+
+This repo is the right place to carry or publish signed catalogs for:
+- approved fog agent images
+- local storage / CSI chart pins
+- ignition profile references
+- installer profile references
+- conformance policy packs
+
+### 2. Opt-in update automation
+
+Once a node is enrolled, this repo may drive:
+- update proposals
+- validation runs
+- policy checks
+- signed rollout receipts
+
+### 3. Training / testing workflow automation
+
+Where fog agents or compute workers need optional community automation for:
+- training pipelines
+- test lanes
+- benchmark runs
+- artifact publication
+
+That orchestration belongs here only after explicit enrollment.
+
+## What does not belong here
+
+This repo should not become a hidden dependency for:
+- substrate boot correctness
+- first-boot disk and mount realization
+- local container runtime viability
+- the canonical contract layer
+
+Those remain upstream in SourceOS, sourceos-spec, and the related runtime/conformance repos.
+
+## Expected follow-up
+
+Future PRs here should add:
+1. fog-related signed catalog structures
+2. policy packs controlling admissible fog updates
+3. rollout receipts / evidence patterns for fog artifacts
+4. explicit opt-in enrollment docs for fog nodes

--- a/policies/fog-policy.rego
+++ b/policies/fog-policy.rego
@@ -1,0 +1,13 @@
+package fog
+
+# Placeholder admissibility rules for fog artifact rollout.
+# This policy is intentionally conservative until the signed catalog and receipt
+# flow is fully wired.
+
+default allow = false
+
+allow if {
+  input.kind == "FogCatalogEntry"
+  input.spec.digest != ""
+  startswith(input.spec.digest, "sha256:")
+}


### PR DESCRIPTION
## Summary

This PR captures the intended **opt-in automation/catalog role** of `socios` for the Fog layer.

It adds `docs/FOG_OPT_IN_AUTOMATION.md` to make explicit that:
- fog nodes must function without `socios`
- enrollment remains explicit and signed
- `socios` is the right place for signed catalogs, rollout automation, and optional testing/training workflows once a node is enrolled

## Why this belongs here

`SociOS-Linux/socios` is the opt-in community automation commons. The Fog layer needs this repo to be clearly positioned as optional distribution/automation, not a hidden substrate dependency.

## Intentionally not included

This PR does **not** yet add:
- actual catalog files
- rollout policies / rego packs
- enrollment flows
- fog-specific update jobs

Those should follow after the role note is agreed.

## Follow-up

Subsequent PRs should add:
1. fog artifact catalogs and pins
2. policy packs for fog update admissibility
3. rollout receipt patterns
4. explicit fog enrollment docs / flows
