### PR TITLE
Fix fog catalog admissibility and placeholder posture

### DIFF
--- a/catalogs/fog/README.md
+++ b/catalogs/fog/README.md
@@ -10,6 +10,15 @@ This directory is the placeholder home for signed fog-related catalogs once a no
 - installer profile references
 - conformance policy pack references
 
+## Admission posture
+
+Catalog entries in this directory are expected to be:
+- explicitly enrolled / policy-allowed
+- digest-pinned
+- verifiable
+
+Placeholder entries may exist for design review, but they must fail the admissibility policy until replaced with real pins.
+
 ## Boundary
 
 These catalogs are **optional** and must never become a hidden dependency for local substrate correctness.

--- a/catalogs/fog/fog-replicator.yaml
+++ b/catalogs/fog/fog-replicator.yaml
@@ -1,4 +1,3 @@
-# Placeholder fog catalog entry for the topic replication agent.
 apiVersion: socios.dev/v1alpha1
 kind: FogCatalogEntry
 metadata:
@@ -8,8 +7,9 @@ spec:
   source:
     kind: image
     ref: ghcr.io/socioprophet/fog-replicator
-  version: 0.0.0-placeholder
-  digest: sha256:REPLACE_ME
+  version: pending-pin
+  digest: ""
+  placeholder: true
   notes:
-    - Replace with a digest-pinned image reference before use.
+    - Placeholder only. This entry must fail admission until a real digest pin is supplied.
     - Intended to replicate Hypercore topic state across enrolled nodes.

--- a/catalogs/fog/fog-worker.yaml
+++ b/catalogs/fog/fog-worker.yaml
@@ -1,4 +1,3 @@
-# Placeholder fog catalog entry for the compute worker agent.
 apiVersion: socios.dev/v1alpha1
 kind: FogCatalogEntry
 metadata:
@@ -8,8 +7,9 @@ spec:
   source:
     kind: image
     ref: ghcr.io/socioprophet/fog-worker
-  version: 0.0.0-placeholder
-  digest: sha256:REPLACE_ME
+  version: pending-pin
+  digest: ""
+  placeholder: true
   notes:
-    - Replace with a digest-pinned image reference before use.
+    - Placeholder only. This entry must fail admission until a real digest pin is supplied.
     - Intended to execute FogCompute work orders and emit usage receipts.

--- a/catalogs/fog/topolvm.yaml
+++ b/catalogs/fog/topolvm.yaml
@@ -1,4 +1,3 @@
-# Placeholder fog catalog entry for local-storage / TopoLVM lane.
 apiVersion: socios.dev/v1alpha1
 kind: FogCatalogEntry
 metadata:
@@ -8,7 +7,8 @@ spec:
   source:
     kind: helm
     ref: topolvm/topolvm
-  version: 0.0.0-placeholder
-  digest: sha256:REPLACE_ME
+  version: pending-pin
+  digest: ""
+  placeholder: true
   notes:
-    - Replace with digest-pinned chart or artifact reference before use.
+    - Placeholder only. This entry must fail admission until a real digest pin is supplied.

--- a/docs/FOG_OPT_IN_AUTOMATION.md
+++ b/docs/FOG_OPT_IN_AUTOMATION.md
@@ -24,6 +24,8 @@ This repo is the right place to carry or publish signed catalogs for:
 - installer profile references
 - conformance policy packs
 
+The current placeholder catalog entries are **intentionally non-admissible** until replaced with real digest pins.
+
 ### 2. Opt-in update automation
 
 Once a node is enrolled, this repo may drive:
@@ -55,7 +57,7 @@ Those remain upstream in SourceOS, sourceos-spec, and the related runtime/confor
 ## Expected follow-up
 
 Future PRs here should add:
-1. fog-related signed catalog structures
-2. policy packs controlling admissible fog updates
+1. real digest-pinned fog catalogs replacing the non-admissible placeholders
+2. richer policy packs controlling admissible fog updates
 3. rollout receipts / evidence patterns for fog artifacts
 4. explicit opt-in enrollment docs for fog nodes

--- a/policies/fog-policy.rego
+++ b/policies/fog-policy.rego
@@ -1,13 +1,24 @@
 package fog
 
-# Placeholder admissibility rules for fog artifact rollout.
-# This policy is intentionally conservative until the signed catalog and receipt
-# flow is fully wired.
+# Hardened admissibility rules for fog artifact rollout.
+# Placeholder or malformed digests must fail by default.
 
 default allow = false
 
+valid_sha256(d) if {
+  regex.match("^sha256:[0-9a-f]{64}$", d)
+}
+
+not_placeholder(v) if {
+  lv := lower(v)
+  lv != "pending-pin"
+  not contains(lv, "replace_me")
+  not contains(lv, "placeholder")
+}
+
 allow if {
   input.kind == "FogCatalogEntry"
-  input.spec.digest != ""
-  startswith(input.spec.digest, "sha256:")
+  valid_sha256(input.spec.digest)
+  not_placeholder(input.spec.version)
+  object.get(input.spec, "placeholder", false) == false
 }


### PR DESCRIPTION
## Summary

This PR hardens the fog opt-in automation lane that was introduced earlier in `socios`.

It updates the existing fog catalog / policy files so placeholder artifacts are **not admissible by default**.

## Included in this PR

- tighten `policies/fog-policy.rego` to require a full `sha256:<64 hex>` digest
- reject placeholder markers / versions in the policy gate
- convert the placeholder fog catalog entries to explicit non-admissible stubs:
  - empty digest
  - `placeholder: true`
  - `pending-pin` version markers
- reconcile fog docs so they clearly describe the current entries as non-admissible placeholders

## Why

The earlier fog automation lane correctly established the boundary that `socios` is optional, but its initial placeholders could still be interpreted as admissible because the policy only checked for a `sha256:` prefix.

This PR fixes that defect without changing the broader lane design.

## Files updated

- `policies/fog-policy.rego`
- `catalogs/fog/README.md`
- `catalogs/fog/topolvm.yaml`
- `catalogs/fog/fog-replicator.yaml`
- `catalogs/fog/fog-worker.yaml`
- `docs/FOG_OPT_IN_AUTOMATION.md`

## Non-goals

- no real production digest pins yet
- no rollout job wiring yet
- no enrollment flow implementation yet

Those should come in later PRs once the approved artifact set exists.
