### PR TITLE
Add Fedora Atomic SkillManifests for software lanes (Flathub/Toolbox/rpm-ostree)

### DIFF
--- a/policies/POLICIES.md
+++ b/policies/POLICIES.md
@@ -1,0 +1,15 @@
+# Policies
+
+This directory contains typed `Policy` artifacts aligned with the SourceOS/SociOS Typed Contracts (spec v2.x).
+
+Policy objects are URN-addressed (`urn:srcos:policy:<id>`) and contain:
+- `scope`: subject selectors, object selectors, and purpose strings
+- `rules`: ordered permit/deny rules with optional typed conditions (CEL/Rego/Cedar/JSONLogic)
+- `obligations`: required actions pre/post/runtime
+
+Current policies:
+- `urn:srcos:policy:socios.optin.signed-intent` — require signed intent for opt-in automation
+- `urn:srcos:policy:host.mutation.requires.review` — require review + rollback plan for host mutations
+
+Notes:
+- Our policy evaluation engine is not wired here yet; these artifacts establish the canonical topology and identifiers.

--- a/policies/README.md
+++ b/policies/README.md
@@ -1,0 +1,7 @@
+# Policies (placeholders)
+
+This directory is a placeholder for policy artifacts referenced by SkillManifests.
+
+In the typed contract model, these should eventually be first-class `Policy` objects (URN-addressed) with a concrete evaluation engine.
+
+For now, we keep them as human-readable policy notes that higher layers can enforce.

--- a/policies/host.mutation.requires.review.json
+++ b/policies/host.mutation.requires.review.json
@@ -1,0 +1,49 @@
+{
+  "id": "urn:srcos:policy:host.mutation.requires.review",
+  "type": "Policy",
+  "specVersion": "2.0.0",
+  "name": "host.mutation.requires.review",
+  "scope": {
+    "subjects": [
+      {"kind": "user"},
+      {"kind": "service"},
+      {"kind": "workload"},
+      {"kind": "any"}
+    ],
+    "objects": [
+      {"objectType": "any", "match": {"resourceKind": "host-mutation"}}
+    ],
+    "purposes": [
+      "os.bootstrap",
+      "host.mutation"
+    ]
+  },
+  "rules": [
+    {
+      "effect": "permit",
+      "operations": ["write"],
+      "condition": {
+        "language": "cel",
+        "expr": {
+          "cel": "context.reviewApproved == true && context.rollbackPlanPresent == true"
+        },
+        "notes": "Permit host mutation only with explicit review approval and an explicit rollback plan."
+      }
+    },
+    {
+      "effect": "deny",
+      "operations": ["write"],
+      "condition": {
+        "language": "cel",
+        "expr": {
+          "cel": "!(context.reviewApproved == true && context.rollbackPlanPresent == true)"
+        },
+        "notes": "Deny if review/rollback requirements are not satisfied."
+      }
+    }
+  ],
+  "obligations": [
+    {"name": "log_access", "when": "runtime", "params": {"channel": "local"}},
+    {"name": "retain_provenance", "when": "post", "params": {"mode": "worm"}}
+  ]
+}

--- a/policies/host.mutation.requires.review.md
+++ b/policies/host.mutation.requires.review.md
@@ -1,0 +1,11 @@
+# urn:srcos:policy:host.mutation.requires.review
+
+Intent: ensure host mutations (rpm-ostree layering, kernel-adjacent changes) are rare and reviewed.
+
+Rule:
+- Host mutations default to review-only.
+- Require a recorded rationale and a rollback plan.
+- Prefer Flatpak/Toolbox whenever feasible.
+- If a package is layered, record the deployment change and verify rollback works.
+
+This is a placeholder policy note until the canonical `Policy` schema is wired to an evaluator.

--- a/policies/socios.optin.signed-intent.json
+++ b/policies/socios.optin.signed-intent.json
@@ -1,0 +1,50 @@
+{
+  "id": "urn:srcos:policy:socios.optin.signed-intent",
+  "type": "Policy",
+  "specVersion": "2.0.0",
+  "name": "socios.optin.signed-intent",
+  "scope": {
+    "subjects": [
+      {"kind": "user"},
+      {"kind": "service"},
+      {"kind": "app"},
+      {"kind": "workload"},
+      {"kind": "any"}
+    ],
+    "objects": [
+      {"objectType": "any", "match": {"resourceKind": "skill"}}
+    ],
+    "purposes": [
+      "os.bootstrap",
+      "automation"
+    ]
+  },
+  "rules": [
+    {
+      "effect": "permit",
+      "operations": ["transform"],
+      "condition": {
+        "language": "cel",
+        "expr": {
+          "cel": "context.signedIntent == true"
+        },
+        "notes": "Permit skill execution only when a user-signed intent record is present (opt-in)."
+      }
+    },
+    {
+      "effect": "deny",
+      "operations": ["transform"],
+      "condition": {
+        "language": "cel",
+        "expr": {
+          "cel": "context.signedIntent != true"
+        },
+        "notes": "Deny if intent is missing."
+      }
+    }
+  ],
+  "obligations": [
+    {"name": "log_access", "when": "runtime", "params": {"channel": "local"}},
+    {"name": "retain_provenance", "when": "post", "params": {"mode": "worm"}}
+  ]
+}

--- a/policies/socios.optin.signed-intent.md
+++ b/policies/socios.optin.signed-intent.md
@@ -1,0 +1,10 @@
+# urn:srcos:policy:socios.optin.signed-intent
+
+Intent: prevent silent mutation.
+
+Rule:
+- No automation runs by default.
+- Any mutation must be preceded by local Proof-of-Life and a user-signed intent record.
+- Artifacts consumed by automation must be digest-pinned and verifiable.
+
+This is a placeholder policy note until the canonical `Policy` schema is wired to an evaluator.

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,12 @@
+# Skills (Capability Manifests)
+
+This directory contains **SkillManifests** (typed capability descriptors) plus their entry docs and optional helper scripts.
+
+These manifests are intended to align with the SourceOS/SociOS Typed Contracts `SkillManifest` schema (spec v2.x).
+
+Operational posture:
+- `socios` is opt-in automation. Nothing here should assume enrollment by default.
+- Any mutation must be gated by user intent (Proof-of-Life + signed intent).
+
+Start here:
+- `skills/fedora-atomic/README.md`

--- a/skills/fedora-atomic/README.md
+++ b/skills/fedora-atomic/README.md
@@ -1,0 +1,14 @@
+# Fedora Atomic skills
+
+These skills codify the Fedora Atomic (Silverblue/Kinoite/Sway Atomic) software lanes:
+
+1) Flatpak (GUI apps)
+2) Toolbox (CLI/dev tools)
+3) rpm-ostree layering (host mutations)
+
+Current skills:
+- `flathub-remote-add` — add Flathub remote (idempotent)
+- `toolbox-bootstrap` — create a toolbox profile and install baseline CLI tools
+- `rpm-ostree-layering` — host package layering guardrails + rollback workflow
+
+Note: these are capability descriptors + runbooks. Actual execution should be gated by policy and signed intent.

--- a/skills/fedora-atomic/flathub-remote-add/SKILL.md
+++ b/skills/fedora-atomic/flathub-remote-add/SKILL.md
@@ -1,0 +1,25 @@
+# flathub-remote-add
+
+Adds Flathub as a Flatpak remote.
+
+## Preconditions
+
+- Running on Fedora Atomic (Silverblue/Kinoite/Sway Atomic) or Fedora Workstation.
+- `flatpak` is installed (it is by default on Atomic desktops).
+- Enrollment: this operation should only be executed when the user has explicitly opted in and signed intent.
+
+## Execute (idempotent)
+
+```bash
+flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+flatpak remotes --show-details
+```
+
+## Verify
+
+- Confirm the `flathub` remote exists.
+- Confirm the URL points to `dl.flathub.org`.
+
+## Notes
+
+This skill does not install any applications; it only adds the remote.

--- a/skills/fedora-atomic/flathub-remote-add/SkillManifest.json
+++ b/skills/fedora-atomic/flathub-remote-add/SkillManifest.json
@@ -1,0 +1,43 @@
+{
+  "id": "urn:srcos:skill:fedora-atomic.flathub-remote-add",
+  "type": "SkillManifest",
+  "specVersion": "2.0.0",
+  "name": "fedora-atomic.flathub-remote-add",
+  "version": "0.1.0",
+  "entryDoc": "skills/fedora-atomic/flathub-remote-add/SKILL.md",
+  "description": "Adds the Flathub Flatpak remote on Fedora Atomic systems in an idempotent, auditable way.",
+  "activationRules": {
+    "commands": [
+      "flathub.setup",
+      "flatpak.remote.add",
+      "fedora.atomic.flathub"
+    ],
+    "filePatterns": [],
+    "intentTags": [
+      "os.bootstrap",
+      "fedora-atomic",
+      "flatpak"
+    ]
+  },
+  "requires": {
+    "binaries": [
+      "flatpak"
+    ],
+    "anyBins": [],
+    "tools": []
+  },
+  "policyBindings": [
+    "urn:srcos:policy:socios.optin.signed-intent"
+  ],
+  "artifactOutputs": [
+    "artifact:stdout",
+    "artifact:receipt"
+  ],
+  "reviewMode": false,
+  "allowShellExecution": true,
+  "protectedPaths": [
+    "/etc",
+    "/usr",
+    "/boot"
+  ]
+}

--- a/skills/fedora-atomic/flathub-remote-add/run.sh
+++ b/skills/fedora-atomic/flathub-remote-add/run.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# flathub-remote-add (idempotent)
+# NOTE: execution should be gated by signed intent in higher layers.
+
+flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+flatpak remotes --show-details

--- a/skills/fedora-atomic/rpm-ostree-layering/SKILL.md
+++ b/skills/fedora-atomic/rpm-ostree-layering/SKILL.md
@@ -1,0 +1,37 @@
+# rpm-ostree-layering
+
+Guardrails for host package layering on Fedora Atomic.
+
+## Why
+
+Layering modifies the host deployment. It is valid for kernel-adjacent or host service requirements, but it should be rare.
+
+## Workflow (review first)
+
+1) Confirm the package truly must be on the host (cannot be Flatpak/Toolbox).
+2) Record intent: what package, why, rollback plan.
+3) Layer package (creates new deployment):
+
+```bash
+rpm-ostree install <package>
+rpm-ostree status
+```
+
+4) Reboot into new deployment:
+
+```bash
+systemctl reboot
+```
+
+## Rollback
+
+If the new deployment is bad:
+
+```bash
+rpm-ostree rollback
+systemctl reboot
+```
+
+## Notes
+
+- This skill is **reviewMode=true** by default (no automatic mutation). A higher-layer policy must explicitly allow execution.

--- a/skills/fedora-atomic/rpm-ostree-layering/SkillManifest.json
+++ b/skills/fedora-atomic/rpm-ostree-layering/SkillManifest.json
@@ -1,0 +1,44 @@
+{
+  "id": "urn:srcos:skill:fedora-atomic.rpm-ostree-layering",
+  "type": "SkillManifest",
+  "specVersion": "2.0.0",
+  "name": "fedora-atomic.rpm-ostree-layering",
+  "version": "0.1.0",
+  "entryDoc": "skills/fedora-atomic/rpm-ostree-layering/SKILL.md",
+  "description": "Guardrails and workflow for rpm-ostree host package layering (sparingly) including rollback.",
+  "activationRules": {
+    "commands": [
+      "rpm-ostree.install",
+      "rpm-ostree.layer",
+      "fedora.atomic.layering"
+    ],
+    "filePatterns": [],
+    "intentTags": [
+      "os.bootstrap",
+      "fedora-atomic",
+      "rpm-ostree"
+    ]
+  },
+  "requires": {
+    "binaries": [
+      "rpm-ostree"
+    ],
+    "anyBins": [],
+    "tools": []
+  },
+  "policyBindings": [
+    "urn:srcos:policy:socios.optin.signed-intent",
+    "urn:srcos:policy:host.mutation.requires.review"
+  ],
+  "artifactOutputs": [
+    "artifact:stdout",
+    "artifact:receipt"
+  ],
+  "reviewMode": true,
+  "allowShellExecution": false,
+  "protectedPaths": [
+    "/etc",
+    "/usr",
+    "/boot"
+  ]
+}

--- a/skills/fedora-atomic/toolbox-bootstrap/SKILL.md
+++ b/skills/fedora-atomic/toolbox-bootstrap/SKILL.md
@@ -1,0 +1,34 @@
+# toolbox-bootstrap
+
+Creates a toolbox container profile and installs baseline tooling inside it.
+
+## Why
+
+On Fedora Atomic, CLI/dev tooling belongs in Toolbox, not on the host.
+This preserves rollback semantics and keeps the host OS immutable.
+
+## Execute
+
+Create + enter:
+
+```bash
+toolbox create --container dev || true
+toolbox enter --container dev
+```
+
+Install baseline tools (inside the toolbox):
+
+```bash
+sudo dnf install -y git make gcc gcc-c++ python3 python3-pip ripgrep fd-find
+```
+
+## Verify
+
+```bash
+toolbox list
+```
+
+## Notes
+
+- For per-project isolation, prefer venv/conda/pixi inside the toolbox.
+- Keep toolbox images small and role-specific (dev vs ops vs forensic).

--- a/skills/fedora-atomic/toolbox-bootstrap/SkillManifest.json
+++ b/skills/fedora-atomic/toolbox-bootstrap/SkillManifest.json
@@ -1,0 +1,43 @@
+{
+  "id": "urn:srcos:skill:fedora-atomic.toolbox-bootstrap",
+  "type": "SkillManifest",
+  "specVersion": "2.0.0",
+  "name": "fedora-atomic.toolbox-bootstrap",
+  "version": "0.1.0",
+  "entryDoc": "skills/fedora-atomic/toolbox-bootstrap/SKILL.md",
+  "description": "Creates a toolbox profile and installs baseline CLI/dev tooling inside it (keeps host immutable).",
+  "activationRules": {
+    "commands": [
+      "toolbox.bootstrap",
+      "fedora.atomic.toolbox",
+      "dev.tools.install"
+    ],
+    "filePatterns": [],
+    "intentTags": [
+      "os.bootstrap",
+      "fedora-atomic",
+      "toolbox"
+    ]
+  },
+  "requires": {
+    "binaries": [
+      "toolbox"
+    ],
+    "anyBins": [],
+    "tools": []
+  },
+  "policyBindings": [
+    "urn:srcos:policy:socios.optin.signed-intent"
+  ],
+  "artifactOutputs": [
+    "artifact:stdout",
+    "artifact:receipt"
+  ],
+  "reviewMode": false,
+  "allowShellExecution": true,
+  "protectedPaths": [
+    "/etc",
+    "/usr",
+    "/boot"
+  ]
+}

--- a/skills/fedora-atomic/toolbox-bootstrap/run.sh
+++ b/skills/fedora-atomic/toolbox-bootstrap/run.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# toolbox-bootstrap
+# NOTE: execution should be gated by signed intent in higher layers.
+
+container_name="dev"
+
+toolbox create --container "${container_name}" || true
+# Entering a toolbox is interactive; we provide a non-interactive install path below.
+
+# Install baseline packages inside toolbox via `toolbox run` to avoid interactive shell.
+toolbox run --container "${container_name}" sudo dnf install -y git make gcc gcc-c++ python3 python3-pip ripgrep fd-find
+
+toolbox list


### PR DESCRIPTION
Codifies Fedora Atomic software supply lanes as typed capabilities (SkillManifests) under `skills/`.

Adds:
- SkillManifests + entry docs + helper scripts:
  - fedora-atomic.flathub-remote-add
  - fedora-atomic.toolbox-bootstrap
  - fedora-atomic.rpm-ostree-layering (reviewMode=true; allowShellExecution=false)
- Placeholder policy notes referenced by SkillManifests:
  - urn:srcos:policy:socios.optin.signed-intent
  - urn:srcos:policy:host.mutation.requires.review

Notes:
- This is a first pass to establish the GitHub topology and typed manifests; enforcement/evaluation wiring is follow-on work.
- `socios` remains opt-in by design.
