### PR TITLE
socios: add FCOS + Foreman/Katello substrate scaffold

### DIFF
--- a/docs/FCOS_FOREMAN_KATELLO_SUBSTRATE.md
+++ b/docs/FCOS_FOREMAN_KATELLO_SUBSTRATE.md
@@ -1,0 +1,47 @@
+# FCOS + Foreman/Katello substrate (v0 scaffold)
+
+This document records the intended substrate split for the SourceOS build and release lane.
+
+## Boundaries
+
+### `SourceOS`
+Owns the substrate artifact truth only:
+- flavors
+- coreos-assembler config
+- Butane / Ignition source material
+- installer surfaces
+- release channels and manifests
+
+### `socios`
+Owns the opt-in automation around that truth:
+- Foreman / Katello management hosts
+- Smart Proxies
+- Tekton pipelines for build/customize/sign/publish/promote
+- Argo CD deployment of K8s-native automation services
+- enrollment, rollout, and promotion automation
+
+### Foreman / Katello
+Own the provisioning/content/lifecycle control plane.
+They are not the image composer.
+
+### FCOS toolchain
+- `coreos-assembler` = thick derivative build lane
+- `coreos-installer` = live ISO / PXE customization and install lane
+
+## Initial implementation slice in this repo
+
+This scaffold adds:
+- Ansible bootstrap for Foreman/Katello on EL9
+- Tekton pipeline skeletons for customized FCOS live ISO and Katello publish
+- Argo CD landing note for cluster-native automation services
+
+## Explicit non-goals in this scaffold
+
+This scaffold does not yet provide:
+- fully pinned images and package sources
+- Smart Proxy rollout automation
+- production Vault/Tang/object-store wiring
+- release-signing implementation
+- smoke tests against a real Foreman/Katello host
+
+Those belong in the next tranche.

--- a/foreman/KATELLO_CONTENT_MODEL.md
+++ b/foreman/KATELLO_CONTENT_MODEL.md
@@ -1,0 +1,46 @@
+# SourceOS content model in Foreman/Katello
+
+This note maps the SourceOS release/build object family onto Foreman/Katello concepts.
+
+## Mapping
+
+### Product
+A Product represents a major SourceOS family, for example:
+- SourceOS Workstation
+- SourceOS Recovery
+- SourceOS Builder
+
+### Repository
+Repositories represent artifact surfaces or content types, for example:
+- custom file repo for ISO and disk images
+- custom file repo for config bundles or branding packs
+- OSTree repo for tree content
+- container repo for bootc/image-mode outputs
+
+### Content View
+A Content View freezes a coherent release snapshot for one family/channel pair.
+
+### Lifecycle Environment
+Lifecycle environments represent release rings such as:
+- dev
+- qa
+- prod
+- customer or site-specific rings
+
+### Activation Key / Enrollment Profile
+Activation keys should map to enrollment and post-install consumption profiles.
+
+## Why this matters
+
+The same flavor can produce many task/customer/site variants without becoming an unmanaged snowflake set:
+- flavor remains stable
+- overlays vary
+- build requests compose them
+- Katello versions and promotes the outputs
+
+## Follow-on
+
+The next tranche should make this mapping executable in automation by adding:
+- post-install seeding for products/repositories/content views/lifecycle envs
+- publish tasks that upload FCOS/SourceOS outputs into the correct repo class
+- activation-key generation or binding from EnrollmentProfile inputs

--- a/gitops/argocd/README.md
+++ b/gitops/argocd/README.md
@@ -1,0 +1,28 @@
+# Argo CD placement for the SourceOS build substrate
+
+Argo CD is used here for the Kubernetes-native parts of the automation stack:
+- Tekton controllers and tasks/pipelines
+- object storage / registry / signing helpers
+- observability components
+- optional policy or secret-management sidecars
+
+## Explicit boundary
+
+Foreman/Katello management hosts are **not** treated as in-cluster app payloads in this scaffold.
+They remain dedicated EL9 management hosts and are provisioned/bootstraped via infrastructure + Ansible.
+
+## Desired posture
+
+- Argo CD reconciles the K8s-native automation substrate
+- Tekton executes build/customize/sign/publish pipelines
+- Foreman/Katello manages content lifecycle and provisioning
+- Smart Proxies serve site-local provisioning/content traffic
+
+## Follow-on
+
+A later tranche should add concrete `Application` or `ApplicationSet` manifests for:
+- Tekton
+- build-worker namespace resources
+- artifact/object store
+- signing/verification helpers
+- observability stack

--- a/infra/ansible/playbooks/foreman-katello-bootstrap.yml
+++ b/infra/ansible/playbooks/foreman-katello-bootstrap.yml
@@ -1,0 +1,7 @@
+---
+- name: Bootstrap Foreman + Katello management host
+  hosts: foreman_katello
+  become: true
+  gather_facts: true
+  roles:
+    - role: foreman_katello_install

--- a/infra/ansible/roles/foreman_katello_install/README.md
+++ b/infra/ansible/roles/foreman_katello_install/README.md
@@ -1,0 +1,29 @@
+# foreman_katello_install role
+
+This role is the first bootstrap scaffold for a dedicated EL9 Foreman/Katello management host.
+
+## Scope
+
+This role currently does three things:
+- asserts the expected management-host substrate (EL9 x86_64-class host)
+- verifies `foreman-installer` is present
+- runs `foreman-installer --scenario katello` when `socios_foreman_dry_run=false`
+
+## Current posture
+
+The role is intentionally conservative:
+- `socios_foreman_dry_run` defaults to `true`
+- package/repository bootstrap is not yet encoded here
+- Smart Proxy, lifecycle-environment seeding, activation keys, and content views are follow-on work
+
+## Variables
+
+See `defaults/main.yml`.
+
+## Follow-on
+
+The next tranche should add:
+- package repository bootstrap for the management host
+- Smart Proxy roles
+- post-install seeding for organizations, locations, lifecycle environments, and content views
+- explicit FCOS custom-file / OSTree / container repository wiring

--- a/infra/ansible/roles/foreman_katello_install/defaults/main.yml
+++ b/infra/ansible/roles/foreman_katello_install/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+socios_foreman_dry_run: true
+socios_foreman_servername: foreman.example.com
+socios_foreman_organization: SourceOS
+socios_foreman_location: Default
+socios_foreman_admin_username: admin
+socios_foreman_admin_password: null
+socios_foreman_lifecycle_environments:
+  - dev
+  - qa
+  - prod

--- a/infra/ansible/roles/foreman_katello_install/tasks/main.yml
+++ b/infra/ansible/roles/foreman_katello_install/tasks/main.yml
@@ -1,0 +1,47 @@
+---
+- name: Assert supported management host substrate
+  ansible.builtin.assert:
+    that:
+      - ansible_os_family == 'RedHat'
+      - (ansible_distribution_major_version | int) >= 9
+      - ansible_architecture in ['x86_64', 'amd64']
+    fail_msg: "Foreman/Katello management hosts must run on dedicated EL9 x86_64-class systems."
+
+- name: Validate admin password is provided when not in dry-run mode
+  ansible.builtin.assert:
+    that:
+      - socios_foreman_admin_password is not none
+      - socios_foreman_admin_password | length > 0
+    fail_msg: "Set socios_foreman_admin_password when socios_foreman_dry_run=false."
+  when: not socios_foreman_dry_run
+
+- name: Check foreman-installer availability
+  ansible.builtin.command:
+    argv: ["foreman-installer", "--help"]
+  changed_when: false
+
+- name: Explain dry-run posture
+  ansible.builtin.debug:
+    msg:
+      - "Dry-run mode enabled; Foreman/Katello installer command is not being executed."
+      - "Set socios_foreman_dry_run=false after package/repository bootstrap is in place."
+  when: socios_foreman_dry_run
+
+- name: Run Foreman/Katello installer
+  ansible.builtin.command:
+    argv:
+      - foreman-installer
+      - --scenario
+      - katello
+      - --foreman-servername
+      - "{{ socios_foreman_servername }}"
+      - --foreman-initial-organization
+      - "{{ socios_foreman_organization }}"
+      - --foreman-initial-location
+      - "{{ socios_foreman_location }}"
+      - --foreman-initial-admin-username
+      - "{{ socios_foreman_admin_username }}"
+      - --foreman-initial-admin-password
+      - "{{ socios_foreman_admin_password }}"
+  no_log: true
+  when: not socios_foreman_dry_run

--- a/pipelines/tekton/pipeline-customize-live-iso.yaml
+++ b/pipelines/tekton/pipeline-customize-live-iso.yaml
@@ -1,0 +1,71 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: sourceos-customize-live-iso
+spec:
+  description: >-
+    First FCOS/SourceOS live ISO pipeline scaffold: customize a live ISO from
+    generated ignition/config inputs and publish it into a Katello custom file repo.
+  params:
+    - name: baseIsoPath
+      type: string
+    - name: liveIgnitionPath
+      type: string
+      default: ""
+    - name: destIgnitionPath
+      type: string
+      default: ""
+    - name: networkDir
+      type: string
+      default: ""
+    - name: outputIsoPath
+      type: string
+      default: out/sourceos-live.iso
+    - name: katelloServerUrl
+      type: string
+    - name: katelloOrganization
+      type: string
+      default: SourceOS
+    - name: katelloProduct
+      type: string
+    - name: katelloRepository
+      type: string
+  workspaces:
+    - name: source
+  tasks:
+    - name: customize-live-iso
+      taskRef:
+        name: customize-live-iso
+      workspaces:
+        - name: source
+          workspace: source
+      params:
+        - name: baseIsoPath
+          value: $(params.baseIsoPath)
+        - name: liveIgnitionPath
+          value: $(params.liveIgnitionPath)
+        - name: destIgnitionPath
+          value: $(params.destIgnitionPath)
+        - name: networkDir
+          value: $(params.networkDir)
+        - name: outputIsoPath
+          value: $(params.outputIsoPath)
+
+    - name: publish-katello
+      runAfter: [customize-live-iso]
+      taskRef:
+        name: publish-katello-file-repo
+      workspaces:
+        - name: source
+          workspace: source
+      params:
+        - name: serverUrl
+          value: $(params.katelloServerUrl)
+        - name: organization
+          value: $(params.katelloOrganization)
+        - name: product
+          value: $(params.katelloProduct)
+        - name: repository
+          value: $(params.katelloRepository)
+        - name: artifactPath
+          value: $(params.outputIsoPath)

--- a/pipelines/tekton/task-customize-live-iso.yaml
+++ b/pipelines/tekton/task-customize-live-iso.yaml
@@ -1,0 +1,57 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: customize-live-iso
+spec:
+  description: >-
+    Scaffold task for customizing a Fedora CoreOS live ISO with live/destination
+    ignition and optional embedded network material.
+  params:
+    - name: toolImage
+      type: string
+      description: Image containing coreos-installer.
+      default: quay.io/coreos/coreos-installer:release
+    - name: baseIsoPath
+      type: string
+      description: Path to the base FCOS ISO inside the workspace.
+    - name: liveIgnitionPath
+      type: string
+      description: Path to the live ignition fragment.
+      default: ""
+    - name: destIgnitionPath
+      type: string
+      description: Path to the destination ignition fragment.
+      default: ""
+    - name: networkDir
+      type: string
+      description: Optional directory of NetworkManager keyfiles to embed.
+      default: ""
+    - name: outputIsoPath
+      type: string
+      description: Output path for the customized ISO inside the workspace.
+  workspaces:
+    - name: source
+      description: SourceOS build context and generated ignition/config artifacts.
+  steps:
+    - name: customize
+      image: $(params.toolImage)
+      workingDir: $(workspaces.source.path)
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        args=(iso customize --output "$(params.outputIsoPath)" "$(params.baseIsoPath)")
+
+        if [[ -n "$(params.liveIgnitionPath)" ]]; then
+          args+=(--live-ignition "$(params.liveIgnitionPath)")
+        fi
+        if [[ -n "$(params.destIgnitionPath)" ]]; then
+          args+=(--dest-ignition "$(params.destIgnitionPath)")
+        fi
+        if [[ -n "$(params.networkDir)" ]]; then
+          while IFS= read -r -d '' file; do
+            args+=(--network-keyfile "$file")
+          done < <(find "$(params.networkDir)" -type f -print0)
+        fi
+
+        coreos-installer "${args[@]}"

--- a/pipelines/tekton/task-publish-katello-file-repo.yaml
+++ b/pipelines/tekton/task-publish-katello-file-repo.yaml
@@ -1,0 +1,58 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: publish-katello-file-repo
+spec:
+  description: >-
+    Scaffold task for uploading a built artifact into a Katello custom file repository
+    using hammer CLI semantics.
+  params:
+    - name: cliImage
+      type: string
+      description: Image containing hammer CLI and any required CA material.
+      default: quay.io/socios/katello-cli:latest
+    - name: serverUrl
+      type: string
+      description: Foreman/Katello base URL.
+    - name: organization
+      type: string
+      description: Katello organization name.
+    - name: product
+      type: string
+      description: Katello product name.
+    - name: repository
+      type: string
+      description: Katello repository name.
+    - name: artifactPath
+      type: string
+      description: Path to the artifact to upload from the workspace.
+  workspaces:
+    - name: source
+      description: Workspace containing the artifact to publish.
+  steps:
+    - name: upload
+      image: $(params.cliImage)
+      workingDir: $(workspaces.source.path)
+      env:
+        - name: KATELLO_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: katello-cli
+              key: password
+        - name: KATELLO_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: katello-cli
+              key: username
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        hammer --server "$(params.serverUrl)" \
+          --username "$KATELLO_USERNAME" \
+          --password "$KATELLO_PASSWORD" \
+          repository upload-content \
+          --organization "$(params.organization)" \
+          --product "$(params.product)" \
+          --name "$(params.repository)" \
+          --path "$(params.artifactPath)"


### PR DESCRIPTION
## Summary

This PR adds the first real FCOS + Foreman/Katello substrate scaffold to `socios`.

It is intentionally additive and bounded. The goal is to create a reviewable automation landing for the SourceOS build/provisioning substrate without pretending the whole stack is already fully wired.

## What lands

### Design / boundary note
- `docs/FCOS_FOREMAN_KATELLO_SUBSTRATE.md`

### Ansible bootstrap scaffold
- `infra/ansible/playbooks/foreman-katello-bootstrap.yml`
- `infra/ansible/roles/foreman_katello_install/defaults/main.yml`
- `infra/ansible/roles/foreman_katello_install/tasks/main.yml`
- `infra/ansible/roles/foreman_katello_install/README.md`

### Katello content model note
- `foreman/KATELLO_CONTENT_MODEL.md`

### Tekton task / pipeline scaffolds
- `pipelines/tekton/task-customize-live-iso.yaml`
- `pipelines/tekton/task-publish-katello-file-repo.yaml`
- `pipelines/tekton/pipeline-customize-live-iso.yaml`

### Argo CD placement note
- `gitops/argocd/README.md`

## Why this belongs in `socios`

`SourceOS` is the immutable substrate and artifact truth.
`socios` is the opt-in automation commons around that substrate.

That makes `socios` the correct place for:
- Foreman/Katello management-host automation
- Smart Proxy and provisioning automation (follow-on)
- Tekton build/customize/sign/publish pipelines
- Argo CD deployment of cluster-native automation services

## Important non-goals in this PR

This PR does **not** yet add:
- package/repository bootstrap for management hosts
- Smart Proxy roles
- post-install seeding for organizations/content views/activation keys
- production-pinned task images and digests
- signing, smoke tests, or promotion automation
- object storage / Tang / Vault / registry deployment

Those are the next implementation tranche.

## Why this matters to the original effort

This is the first upstream automation scaffold directly tied to the original purpose of the chat:
- users build SourceOS/FCOS-derived artifacts
- artifacts can become downloadable images, customized live USB installers, or network-bootable install media
- Foreman/Katello becomes the enterprise provisioning/content lifecycle plane around those artifacts
- Tekton becomes the composition/publish executor
- Argo CD reconciles the K8s-native automation substrate
