### PR TITLE
socios: add smoke-runner base image digest verification policy

### DIFF
--- a/images/sourceos-smoke-runner/README.md
+++ b/images/sourceos-smoke-runner/README.md
@@ -14,9 +14,10 @@ The image provides a minimal runtime for `tools/sourceos-smoke-runner`:
 - base image is configurable through `BASE_IMAGE`
 - the Containerfile requires explicit `BASE_IMAGE` input
 - the Tekton build task can enforce digest-pinned base images with `requirePinnedBase=true`
-- `image-policy.yaml` records digest, SBOM, scan, provenance, evidence-bundle, and signing expectations without inventing an unverified digest
-- the Tekton image pipeline now builds the image, emits an SBOM, runs a scanner task, emits a provenance receipt, bundles image evidence, and can optionally run attestation tasks
-- attestation remains disabled by default until cross-stack signing authority is finalized
+- the Tekton image pipeline verifies the base image digest before build and records a `SmokeRunnerBaseImageReceipt`
+- `image-policy.yaml` records digest, base-image verification, SBOM, scan, provenance, evidence-bundle, and signing expectations without inventing an unverified digest
+- the Tekton image pipeline builds the image, emits an SBOM, runs a scanner task, emits a provenance receipt, bundles image evidence, and can optionally run attestation and promotion tasks
+- attestation and promotion remain disabled by default until cross-stack signing and release authority are finalized
 
 ## Follow-on
 

--- a/images/sourceos-smoke-runner/README.md
+++ b/images/sourceos-smoke-runner/README.md
@@ -15,13 +15,16 @@ The image provides a minimal runtime for `tools/sourceos-smoke-runner`:
 - the Containerfile requires explicit `BASE_IMAGE` input
 - the Tekton build task can enforce digest-pinned base images with `requirePinnedBase=true`
 - the Tekton image pipeline verifies the base image digest before build and records a `SmokeRunnerBaseImageReceipt`
+- `task-image-policy.yaml` records task-image digest requirements for release-grade pipelines
 - `image-policy.yaml` records digest, base-image verification, SBOM, scan, provenance, evidence-bundle, and signing expectations without inventing an unverified digest
-- the Tekton image pipeline builds the image, emits an SBOM, runs a scanner task, emits a provenance receipt, bundles image evidence, and can optionally run attestation and promotion tasks
-- attestation and promotion remain disabled by default until cross-stack signing and release authority are finalized
+- `evidence-publication-policy.yaml` records the required evidence set before catalog or registry publication
+- `promotion-policy.yaml` records manual release-candidate promotion expectations and required evidence
+- the Tekton image pipeline checks task-image refs, verifies the base image, builds the image, emits an SBOM, runs a scanner task, emits a provenance receipt, bundles image evidence, optionally attests, optionally promotes, and optionally emits an evidence-publication receipt
+- attestation, promotion, and publication remain disabled by default until cross-stack signing and release authority are finalized
 
 ## Follow-on
 
 The next tranche should add:
 - verified base image digest replacement in `image-policy.yaml`
-- signed SBOM / provenance bundle publication policy
-- promotion into the SourceOS/SociOS registry catalog
+- verified task image digest replacement in `task-image-policy.yaml`
+- concrete SourceOS/SociOS registry catalog publication implementation

--- a/images/sourceos-smoke-runner/evidence-publication-policy.yaml
+++ b/images/sourceos-smoke-runner/evidence-publication-policy.yaml
@@ -1,0 +1,26 @@
+apiVersion: socios.sourceos.ai/v0
+kind: EvidencePublicationPolicy
+metadata:
+  name: sourceos-smoke-runner-image-evidence
+spec:
+  publicationMode: manual
+  publicationEnabledByDefault: false
+  subjectRef: quay.io/socios/sourceos-smoke-runner:dev
+  targetCatalogRef: sourceos://catalog/images/sourceos-smoke-runner
+  requiredEvidence:
+    - .workstation/reports/images/sourceos-smoke-runner-base-image.json
+    - .workstation/reports/images/sourceos-smoke-runner-task-images.json
+    - .workstation/reports/images/sourceos-smoke-runner-build.json
+    - .workstation/reports/sbom/sourceos-smoke-runner.spdx.json
+    - .workstation/reports/scans/sourceos-smoke-runner-grype.json
+    - .workstation/reports/provenance/sourceos-smoke-runner-provenance.json
+    - .workstation/reports/evidence/sourceos-smoke-runner-evidence.json
+  attestations:
+    requiredForRelease: false
+    evidenceAttestationPath: .workstation/reports/attest/sourceos-smoke-runner-evidence.sig
+    imageAttestationPath: .workstation/reports/attest/sourceos-smoke-runner.sig
+  receiptPath: .workstation/reports/publication/sourceos-smoke-runner-evidence-publication.json
+  notes:
+    - Publication is disabled by default.
+    - This policy records the required evidence set before catalog or registry publication.
+    - Final SourceOS/SociOS catalog publication authority is intentionally deferred.

--- a/images/sourceos-smoke-runner/image-policy.yaml
+++ b/images/sourceos-smoke-runner/image-policy.yaml
@@ -8,6 +8,7 @@ spec:
     ref: registry.fedoraproject.org/fedora-minimal
     digest: REPLACE_WITH_VERIFIED_DIGEST
     requireDigest: true
+    verificationReceiptPath: .workstation/reports/images/sourceos-smoke-runner-base-image.json
   sbom:
     required: true
     format: spdx-json
@@ -23,6 +24,7 @@ spec:
     requiredRefs:
       - imageRef
       - baseImage
+      - baseImageReceiptPath
       - sbomPath
       - scanPath
   evidenceBundle:
@@ -36,5 +38,6 @@ spec:
     signaturePath: .workstation/reports/attest/sourceos-smoke-runner.sig
   notes:
     - Replace baseImage.digest with a verified digest before enabling release publication.
+    - Runtime verification records the resolved digest in baseImage.verificationReceiptPath.
     - Keep signing optional until cross-stack signing authority is finalized.
     - Scan, provenance, and evidence-bundle records are required for release-grade image promotion.

--- a/images/sourceos-smoke-runner/task-image-policy.yaml
+++ b/images/sourceos-smoke-runner/task-image-policy.yaml
@@ -1,0 +1,40 @@
+apiVersion: socios.sourceos.ai/v0
+kind: TaskImagePolicy
+metadata:
+  name: sourceos-smoke-runner-image-pipeline
+spec:
+  requireDigestForRelease: true
+  verificationReceiptPath: .workstation/reports/images/sourceos-smoke-runner-task-images.json
+  taskImages:
+    - name: builderImage
+      defaultRef: quay.io/buildah/stable:latest
+      requiredTool: buildah
+      digest: REPLACE_WITH_VERIFIED_DIGEST
+    - name: sbomImage
+      defaultRef: anchore/syft:latest
+      requiredTool: syft
+      digest: REPLACE_WITH_VERIFIED_DIGEST
+    - name: scannerImage
+      defaultRef: anchore/grype:latest
+      requiredTool: grype
+      digest: REPLACE_WITH_VERIFIED_DIGEST
+    - name: signingImage
+      defaultRef: gcr.io/projectsigstore/cosign:latest
+      requiredTool: cosign
+      digest: REPLACE_WITH_VERIFIED_DIGEST
+    - name: publisherImage
+      defaultRef: quay.io/skopeo/stable:latest
+      requiredTool: skopeo
+      digest: REPLACE_WITH_VERIFIED_DIGEST
+    - name: inspectorImage
+      defaultRef: quay.io/skopeo/stable:latest
+      requiredTool: skopeo
+      digest: REPLACE_WITH_VERIFIED_DIGEST
+    - name: shellUtilityImage
+      defaultRef: docker.io/library/busybox:latest
+      requiredTool: sh
+      digest: REPLACE_WITH_VERIFIED_DIGEST
+  notes:
+    - This policy records task-image digest requirements for release-grade pipelines.
+    - Defaults remain tag-based for scaffolding until verified digests are supplied.
+    - Set requirePinnedTaskImages=true in the pipeline to enforce digest-pinned task image refs.

--- a/pipelines/tekton/pipeline-build-smoke-runner-image.yaml
+++ b/pipelines/tekton/pipeline-build-smoke-runner-image.yaml
@@ -4,9 +4,9 @@ metadata:
   name: sourceos-build-smoke-runner-image
 spec:
   description: >-
-    Verify base image, build, optionally publish, generate SBOM, scan, emit provenance,
-    bundle evidence, optionally attest, and optionally promote the SourceOS smoke-runner
-    image used by live ISO smoke checks.
+    Check task image refs, verify base image, build, optionally publish, generate SBOM,
+    scan, emit provenance, bundle evidence, optionally attest, and optionally promote
+    the SourceOS smoke-runner image used by live ISO smoke checks.
   params:
     - name: imageRef
       type: string
@@ -20,6 +20,9 @@ spec:
     - name: requirePinnedBase
       type: string
       default: "true"
+    - name: requirePinnedTaskImages
+      type: string
+      default: "false"
     - name: push
       type: string
       default: "false"
@@ -47,13 +50,41 @@ spec:
     - name: inspectorImage
       type: string
       default: quay.io/skopeo/stable:latest
+    - name: utilityImage
+      type: string
+      default: docker.io/library/busybox:latest
     - name: failOnSeverity
       type: string
       default: high
   workspaces:
     - name: source
   tasks:
+    - name: check-smoke-runner-task-images
+      taskRef:
+        name: check-smoke-runner-task-images
+      workspaces:
+        - name: source
+          workspace: source
+      params:
+        - name: requirePinnedTaskImages
+          value: $(params.requirePinnedTaskImages)
+        - name: builderImage
+          value: $(params.builderImage)
+        - name: sbomImage
+          value: $(params.sbomImage)
+        - name: scannerImage
+          value: $(params.scannerImage)
+        - name: attestImage
+          value: $(params.signingImage)
+        - name: publisherImage
+          value: $(params.publisherImage)
+        - name: inspectorImage
+          value: $(params.inspectorImage)
+        - name: utilityImage
+          value: $(params.utilityImage)
+
     - name: verify-smoke-runner-base-image
+      runAfter: [check-smoke-runner-task-images]
       taskRef:
         name: verify-smoke-runner-base-image
       workspaces:

--- a/pipelines/tekton/pipeline-build-smoke-runner-image.yaml
+++ b/pipelines/tekton/pipeline-build-smoke-runner-image.yaml
@@ -4,9 +4,9 @@ metadata:
   name: sourceos-build-smoke-runner-image
 spec:
   description: >-
-    Build, optionally publish, generate SBOM, scan, emit provenance, bundle evidence,
-    optionally attest, and optionally promote the SourceOS smoke-runner image used by
-    live ISO smoke checks.
+    Verify base image, build, optionally publish, generate SBOM, scan, emit provenance,
+    bundle evidence, optionally attest, and optionally promote the SourceOS smoke-runner
+    image used by live ISO smoke checks.
   params:
     - name: imageRef
       type: string
@@ -29,9 +29,6 @@ spec:
     - name: attestEvidence
       type: string
       default: "false"
-    - name: promote
-      type: string
-      default: "false"
     - name: builderImage
       type: string
       default: quay.io/buildah/stable:latest
@@ -47,13 +44,31 @@ spec:
     - name: publisherImage
       type: string
       default: quay.io/skopeo/stable:latest
+    - name: inspectorImage
+      type: string
+      default: quay.io/skopeo/stable:latest
     - name: failOnSeverity
       type: string
       default: high
   workspaces:
     - name: source
   tasks:
+    - name: verify-smoke-runner-base-image
+      taskRef:
+        name: verify-smoke-runner-base-image
+      workspaces:
+        - name: source
+          workspace: source
+      params:
+        - name: baseImage
+          value: $(params.baseImage)
+        - name: requirePinnedBase
+          value: $(params.requirePinnedBase)
+        - name: inspectorImage
+          value: $(params.inspectorImage)
+
     - name: build-smoke-runner-image
+      runAfter: [verify-smoke-runner-base-image]
       taskRef:
         name: build-smoke-runner-image
       workspaces:

--- a/pipelines/tekton/pipeline-build-smoke-runner-image.yaml
+++ b/pipelines/tekton/pipeline-build-smoke-runner-image.yaml
@@ -5,8 +5,8 @@ metadata:
 spec:
   description: >-
     Check task image refs, verify base image, build, optionally publish, generate SBOM,
-    scan, emit provenance, bundle evidence, optionally attest, and optionally promote
-    the SourceOS smoke-runner image used by live ISO smoke checks.
+    scan, emit provenance, bundle evidence, optionally attest, optionally promote, and
+    optionally publish the evidence receipt for the SourceOS smoke-runner image.
   params:
     - name: imageRef
       type: string
@@ -30,6 +30,9 @@ spec:
       type: string
       default: "false"
     - name: attestEvidence
+      type: string
+      default: "false"
+    - name: publishEvidence
       type: string
       default: "false"
     - name: builderImage
@@ -56,6 +59,9 @@ spec:
     - name: failOnSeverity
       type: string
       default: high
+    - name: targetCatalogRef
+      type: string
+      default: sourceos://catalog/images/sourceos-smoke-runner
   workspaces:
     - name: source
   tasks:
@@ -215,3 +221,18 @@ spec:
           value: $(params.promote)
         - name: publisherImage
           value: $(params.publisherImage)
+
+    - name: publish-smoke-runner-image-evidence
+      runAfter: [promote-smoke-runner-image]
+      taskRef:
+        name: publish-smoke-runner-image-evidence
+      workspaces:
+        - name: source
+          workspace: source
+      params:
+        - name: enabled
+          value: $(params.publishEvidence)
+        - name: imageRef
+          value: $(params.imageRef)
+        - name: targetCatalogRef
+          value: $(params.targetCatalogRef)

--- a/pipelines/tekton/task-bundle-smoke-runner-image-evidence.yaml
+++ b/pipelines/tekton/task-bundle-smoke-runner-image-evidence.yaml
@@ -12,6 +12,9 @@ spec:
     - name: baseImage
       type: string
       default: registry.fedoraproject.org/fedora-minimal@sha256:REPLACE_WITH_VERIFIED_DIGEST
+    - name: baseImageReceiptPath
+      type: string
+      default: .workstation/reports/images/sourceos-smoke-runner-base-image.json
     - name: buildReceiptPath
       type: string
       default: .workstation/reports/images/sourceos-smoke-runner-build.json
@@ -44,6 +47,7 @@ spec:
           "kind": "SmokeRunnerImageEvidenceBundle",
           "imageRef": "$(params.imageRef)",
           "baseImage": "$(params.baseImage)",
+          "baseImageReceiptPath": "$(params.baseImageReceiptPath)",
           "buildReceiptPath": "$(params.buildReceiptPath)",
           "sbomPath": "$(params.sbomPath)",
           "scanPath": "$(params.scanPath)",

--- a/pipelines/tekton/task-check-smoke-runner-task-images.yaml
+++ b/pipelines/tekton/task-check-smoke-runner-task-images.yaml
@@ -38,7 +38,7 @@ spec:
       description: Workspace for receipt output.
   steps:
     - name: check
-      image: docker.io/library/busybox:latest
+      image: $(params.utilityImage)
       workingDir: $(workspaces.source.path)
       script: |
         #!/bin/sh

--- a/pipelines/tekton/task-check-smoke-runner-task-images.yaml
+++ b/pipelines/tekton/task-check-smoke-runner-task-images.yaml
@@ -1,0 +1,66 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: check-smoke-runner-task-images
+spec:
+  description: >-
+    Check task image references used by the SourceOS smoke-runner image pipeline.
+  params:
+    - name: requirePinnedTaskImages
+      type: string
+      default: "false"
+    - name: builderImage
+      type: string
+      default: quay.io/buildah/stable:latest
+    - name: sbomImage
+      type: string
+      default: anchore/syft:latest
+    - name: scannerImage
+      type: string
+      default: anchore/grype:latest
+    - name: attestImage
+      type: string
+      default: gcr.io/projectsigstore/cosign:latest
+    - name: publisherImage
+      type: string
+      default: quay.io/skopeo/stable:latest
+    - name: inspectorImage
+      type: string
+      default: quay.io/skopeo/stable:latest
+    - name: utilityImage
+      type: string
+      default: docker.io/library/busybox:latest
+    - name: receiptPath
+      type: string
+      default: .workstation/reports/images/sourceos-smoke-runner-task-images.json
+  workspaces:
+    - name: source
+      description: Workspace for receipt output.
+  steps:
+    - name: check
+      image: docker.io/library/busybox:latest
+      workingDir: $(workspaces.source.path)
+      script: |
+        #!/bin/sh
+        set -eu
+        mkdir -p "$(dirname "$(params.receiptPath)")"
+        if [ "$(params.requirePinnedTaskImages)" = "true" ]; then
+          for ref in "$(params.builderImage)" "$(params.sbomImage)" "$(params.scannerImage)" "$(params.attestImage)" "$(params.publisherImage)" "$(params.inspectorImage)" "$(params.utilityImage)"; do
+            case "$ref" in *@sha256:*) ;; *) echo "task image reference must include digest" >&2; exit 2 ;; esac
+          done
+        fi
+        cat > "$(params.receiptPath)" <<JSON
+        {
+          "apiVersion": "socios.sourceos.ai/v0",
+          "kind": "SmokeRunnerTaskImageReferenceReceipt",
+          "requirePinnedTaskImages": "$(params.requirePinnedTaskImages)",
+          "builderImage": "$(params.builderImage)",
+          "sbomImage": "$(params.sbomImage)",
+          "scannerImage": "$(params.scannerImage)",
+          "attestImage": "$(params.attestImage)",
+          "publisherImage": "$(params.publisherImage)",
+          "inspectorImage": "$(params.inspectorImage)",
+          "utilityImage": "$(params.utilityImage)",
+          "receiptPath": "$(params.receiptPath)"
+        }
+        JSON

--- a/pipelines/tekton/task-publish-smoke-runner-image-evidence.yaml
+++ b/pipelines/tekton/task-publish-smoke-runner-image-evidence.yaml
@@ -1,0 +1,81 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: publish-smoke-runner-image-evidence
+spec:
+  description: >-
+    Check and optionally publish the SourceOS smoke-runner image evidence set.
+  params:
+    - name: enabled
+      type: string
+      default: "false"
+    - name: imageRef
+      type: string
+      default: quay.io/socios/sourceos-smoke-runner:dev
+    - name: targetCatalogRef
+      type: string
+      default: sourceos://catalog/images/sourceos-smoke-runner
+    - name: baseImageReceiptPath
+      type: string
+      default: .workstation/reports/images/sourceos-smoke-runner-base-image.json
+    - name: taskImageReceiptPath
+      type: string
+      default: .workstation/reports/images/sourceos-smoke-runner-task-images.json
+    - name: buildReceiptPath
+      type: string
+      default: .workstation/reports/images/sourceos-smoke-runner-build.json
+    - name: sbomPath
+      type: string
+      default: .workstation/reports/sbom/sourceos-smoke-runner.spdx.json
+    - name: scanPath
+      type: string
+      default: .workstation/reports/scans/sourceos-smoke-runner-grype.json
+    - name: provenancePath
+      type: string
+      default: .workstation/reports/provenance/sourceos-smoke-runner-provenance.json
+    - name: evidenceBundlePath
+      type: string
+      default: .workstation/reports/evidence/sourceos-smoke-runner-evidence.json
+    - name: receiptPath
+      type: string
+      default: .workstation/reports/publication/sourceos-smoke-runner-evidence-publication.json
+  workspaces:
+    - name: source
+      description: Workspace containing image evidence outputs.
+  steps:
+    - name: publish
+      image: docker.io/library/busybox:latest
+      workingDir: $(workspaces.source.path)
+      script: |
+        #!/bin/sh
+        set -eu
+        mkdir -p "$(dirname "$(params.receiptPath)")"
+        test -f "$(params.baseImageReceiptPath)"
+        test -f "$(params.taskImageReceiptPath)"
+        test -f "$(params.buildReceiptPath)"
+        test -f "$(params.sbomPath)"
+        test -f "$(params.scanPath)"
+        test -f "$(params.provenancePath)"
+        test -f "$(params.evidenceBundlePath)"
+        status="skipped"
+        if [ "$(params.enabled)" = "true" ]; then
+          status="publication-requested"
+        fi
+        cat > "$(params.receiptPath)" <<JSON
+        {
+          "apiVersion": "socios.sourceos.ai/v0",
+          "kind": "SmokeRunnerImageEvidencePublicationReceipt",
+          "imageRef": "$(params.imageRef)",
+          "targetCatalogRef": "$(params.targetCatalogRef)",
+          "enabled": "$(params.enabled)",
+          "status": "${status}",
+          "baseImageReceiptPath": "$(params.baseImageReceiptPath)",
+          "taskImageReceiptPath": "$(params.taskImageReceiptPath)",
+          "buildReceiptPath": "$(params.buildReceiptPath)",
+          "sbomPath": "$(params.sbomPath)",
+          "scanPath": "$(params.scanPath)",
+          "provenancePath": "$(params.provenancePath)",
+          "evidenceBundlePath": "$(params.evidenceBundlePath)",
+          "receiptPath": "$(params.receiptPath)"
+        }
+        JSON

--- a/pipelines/tekton/task-verify-smoke-runner-base-image.yaml
+++ b/pipelines/tekton/task-verify-smoke-runner-base-image.yaml
@@ -1,0 +1,52 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: verify-smoke-runner-base-image
+spec:
+  description: >-
+    Verify and record the SourceOS smoke-runner base image digest before build.
+  params:
+    - name: inspectorImage
+      type: string
+      description: Image containing skopeo.
+      default: quay.io/skopeo/stable:latest
+    - name: baseImage
+      type: string
+      description: Base image ref supplied to the smoke-runner build.
+      default: registry.fedoraproject.org/fedora-minimal@sha256:REPLACE_WITH_VERIFIED_DIGEST
+    - name: requirePinnedBase
+      type: string
+      description: Fail unless baseImage is digest-pinned.
+      default: "true"
+    - name: receiptPath
+      type: string
+      description: Output receipt path.
+      default: .workstation/reports/images/sourceos-smoke-runner-base-image.json
+  workspaces:
+    - name: source
+      description: Workspace for receipt output.
+  steps:
+    - name: verify
+      image: $(params.inspectorImage)
+      workingDir: $(workspaces.source.path)
+      script: |
+        #!/usr/bin/env sh
+        set -eu
+        mkdir -p "$(dirname "$(params.receiptPath)")"
+        if [ "$(params.requirePinnedBase)" = "true" ]; then
+          case "$(params.baseImage)" in
+            *@sha256:*) ;;
+            *) echo "baseImage must be digest-pinned when requirePinnedBase=true" >&2; exit 2 ;;
+          esac
+        fi
+        digest="$(skopeo inspect --format '{{.Digest}}' "docker://$(params.baseImage)")"
+        cat > "$(params.receiptPath)" <<JSON
+        {
+          "apiVersion": "socios.sourceos.ai/v0",
+          "kind": "SmokeRunnerBaseImageReceipt",
+          "baseImage": "$(params.baseImage)",
+          "requirePinnedBase": "$(params.requirePinnedBase)",
+          "resolvedDigest": "${digest}",
+          "receiptPath": "$(params.receiptPath)"
+        }
+        JSON


### PR DESCRIPTION
## Summary

Follow-on to the merged SourceOS/FCOS build substrate tranche.

This PR narrows in on the smoke-runner image release lane and adds base-image verification, task-image policy checks, and evidence-publication policy/receipt scaffolding without hardcoding unverified digests.

## What lands

- `pipelines/tekton/task-verify-smoke-runner-base-image.yaml`
- `pipelines/tekton/task-check-smoke-runner-task-images.yaml`
- `pipelines/tekton/task-publish-smoke-runner-image-evidence.yaml`
- `images/sourceos-smoke-runner/task-image-policy.yaml`
- `images/sourceos-smoke-runner/evidence-publication-policy.yaml`
- pipeline wiring so task-image checks and base-image verification run before image build
- pipeline wiring so evidence publication receipt runs after promotion
- `SmokeRunnerBaseImageReceipt` included in the image evidence bundle
- `image-policy.yaml` updated with `baseImage.verificationReceiptPath`
- smoke-runner image README update

## Why

The previous tranche required digest-pinned base images for release-grade builds but intentionally did not invent a digest.

This PR makes that executable by verifying the supplied base image with `skopeo inspect`, recording the resolved digest, and carrying that receipt into the image evidence bundle.

It also adds task-image policy checks for Buildah, Syft, Grype, Cosign, Skopeo, and BusyBox-style utility images, plus a disabled-by-default evidence-publication receipt for the smoke-runner image evidence set.

## Still not included

- replacing `REPLACE_WITH_VERIFIED_DIGEST` with known-good digests
- resolving and pinning every task image digest in-tree
- concrete SourceOS/SociOS catalog publication implementation
