### PR TITLE
socios: resolve smoke-runner task image digests

### DIFF
--- a/images/sourceos-smoke-runner/README.md
+++ b/images/sourceos-smoke-runner/README.md
@@ -16,10 +16,11 @@ The image provides a minimal runtime for `tools/sourceos-smoke-runner`:
 - the Tekton build task can enforce digest-pinned base images with `requirePinnedBase=true`
 - the Tekton image pipeline verifies the base image digest before build and records a `SmokeRunnerBaseImageReceipt`
 - `task-image-policy.yaml` records task-image digest requirements for release-grade pipelines
+- the Tekton image pipeline records both a task-image reference-check receipt and a task-image digest-resolution receipt
 - `image-policy.yaml` records digest, base-image verification, SBOM, scan, provenance, evidence-bundle, and signing expectations without inventing an unverified digest
 - `evidence-publication-policy.yaml` records the required evidence set before catalog or registry publication
 - `promotion-policy.yaml` records manual release-candidate promotion expectations and required evidence
-- the Tekton image pipeline checks task-image refs, verifies the base image, builds the image, emits an SBOM, runs a scanner task, emits a provenance receipt, bundles image evidence, optionally attests, optionally promotes, and optionally emits an evidence-publication receipt
+- the Tekton image pipeline checks task-image refs, resolves task-image digests, verifies the base image, builds the image, emits an SBOM, runs a scanner task, emits a provenance receipt, bundles image evidence, optionally attests, optionally promotes, and optionally emits an evidence-publication receipt
 - attestation, promotion, and publication remain disabled by default until cross-stack signing and release authority are finalized
 
 ## Follow-on

--- a/images/sourceos-smoke-runner/task-image-policy.yaml
+++ b/images/sourceos-smoke-runner/task-image-policy.yaml
@@ -4,7 +4,8 @@ metadata:
   name: sourceos-smoke-runner-image-pipeline
 spec:
   requireDigestForRelease: true
-  verificationReceiptPath: .workstation/reports/images/sourceos-smoke-runner-task-images.json
+  referenceCheckReceiptPath: .workstation/reports/images/sourceos-smoke-runner-task-images.json
+  digestResolutionReceiptPath: .workstation/reports/images/sourceos-smoke-runner-task-image-digests.json
   taskImages:
     - name: builderImage
       defaultRef: quay.io/buildah/stable:latest
@@ -37,4 +38,5 @@ spec:
   notes:
     - This policy records task-image digest requirements for release-grade pipelines.
     - Defaults remain tag-based for scaffolding until verified digests are supplied.
+    - The pipeline now emits both a reference-shape receipt and a digest-resolution receipt.
     - Set requirePinnedTaskImages=true in the pipeline to enforce digest-pinned task image refs.

--- a/pipelines/tekton/pipeline-build-smoke-runner-image.yaml
+++ b/pipelines/tekton/pipeline-build-smoke-runner-image.yaml
@@ -4,9 +4,10 @@ metadata:
   name: sourceos-build-smoke-runner-image
 spec:
   description: >-
-    Check task image refs, verify base image, build, optionally publish, generate SBOM,
-    scan, emit provenance, bundle evidence, optionally attest, optionally promote, and
-    optionally publish the evidence receipt for the SourceOS smoke-runner image.
+    Check task image refs, resolve task image digests, verify base image, build,
+    optionally publish, generate SBOM, scan, emit provenance, bundle evidence,
+    optionally attest, optionally promote, and optionally publish the evidence receipt
+    for the SourceOS smoke-runner image.
   params:
     - name: imageRef
       type: string
@@ -89,8 +90,33 @@ spec:
         - name: utilityImage
           value: $(params.utilityImage)
 
-    - name: verify-smoke-runner-base-image
+    - name: resolve-smoke-runner-task-image-digests
       runAfter: [check-smoke-runner-task-images]
+      taskRef:
+        name: resolve-smoke-runner-task-image-digests
+      workspaces:
+        - name: source
+          workspace: source
+      params:
+        - name: resolverImage
+          value: $(params.inspectorImage)
+        - name: builderImage
+          value: $(params.builderImage)
+        - name: sbomImage
+          value: $(params.sbomImage)
+        - name: scannerImage
+          value: $(params.scannerImage)
+        - name: attestImage
+          value: $(params.signingImage)
+        - name: publisherImage
+          value: $(params.publisherImage)
+        - name: inspectorImage
+          value: $(params.inspectorImage)
+        - name: utilityImage
+          value: $(params.utilityImage)
+
+    - name: verify-smoke-runner-base-image
+      runAfter: [resolve-smoke-runner-task-image-digests]
       taskRef:
         name: verify-smoke-runner-base-image
       workspaces:

--- a/pipelines/tekton/task-resolve-smoke-runner-task-image-digests.yaml
+++ b/pipelines/tekton/task-resolve-smoke-runner-task-image-digests.yaml
@@ -1,0 +1,73 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: resolve-smoke-runner-task-image-digests
+spec:
+  description: >-
+    Resolve and record digests for task images used by the SourceOS smoke-runner
+    image pipeline.
+  params:
+    - name: resolverImage
+      type: string
+      description: Image containing skopeo.
+      default: quay.io/skopeo/stable:latest
+    - name: builderImage
+      type: string
+      default: quay.io/buildah/stable:latest
+    - name: sbomImage
+      type: string
+      default: anchore/syft:latest
+    - name: scannerImage
+      type: string
+      default: anchore/grype:latest
+    - name: attestImage
+      type: string
+      default: gcr.io/projectsigstore/cosign:latest
+    - name: publisherImage
+      type: string
+      default: quay.io/skopeo/stable:latest
+    - name: inspectorImage
+      type: string
+      default: quay.io/skopeo/stable:latest
+    - name: utilityImage
+      type: string
+      default: docker.io/library/busybox:latest
+    - name: receiptPath
+      type: string
+      default: .workstation/reports/images/sourceos-smoke-runner-task-image-digests.json
+  workspaces:
+    - name: source
+      description: Workspace for digest resolution receipt.
+  steps:
+    - name: resolve
+      image: $(params.resolverImage)
+      workingDir: $(workspaces.source.path)
+      script: |
+        #!/usr/bin/env sh
+        set -eu
+        mkdir -p "$(dirname "$(params.receiptPath)")"
+        resolve_digest() {
+          ref="$1"
+          skopeo inspect --format '{{.Digest}}' "docker://${ref}"
+        }
+        builder_digest="$(resolve_digest "$(params.builderImage)")"
+        sbom_digest="$(resolve_digest "$(params.sbomImage)")"
+        scanner_digest="$(resolve_digest "$(params.scannerImage)")"
+        attest_digest="$(resolve_digest "$(params.attestImage)")"
+        publisher_digest="$(resolve_digest "$(params.publisherImage)")"
+        inspector_digest="$(resolve_digest "$(params.inspectorImage)")"
+        utility_digest="$(resolve_digest "$(params.utilityImage)")"
+        cat > "$(params.receiptPath)" <<JSON
+        {
+          "apiVersion": "socios.sourceos.ai/v0",
+          "kind": "SmokeRunnerTaskImageDigestReceipt",
+          "builderImage": {"ref": "$(params.builderImage)", "digest": "${builder_digest}"},
+          "sbomImage": {"ref": "$(params.sbomImage)", "digest": "${sbom_digest}"},
+          "scannerImage": {"ref": "$(params.scannerImage)", "digest": "${scanner_digest}"},
+          "attestImage": {"ref": "$(params.attestImage)", "digest": "${attest_digest}"},
+          "publisherImage": {"ref": "$(params.publisherImage)", "digest": "${publisher_digest}"},
+          "inspectorImage": {"ref": "$(params.inspectorImage)", "digest": "${inspector_digest}"},
+          "utilityImage": {"ref": "$(params.utilityImage)", "digest": "${utility_digest}"},
+          "receiptPath": "$(params.receiptPath)"
+        }
+        JSON


### PR DESCRIPTION
## Summary

Follow-on to the merged smoke-runner image release-lane policy work.

This PR adds digest-resolution receipts for the Tekton task images used by the SourceOS smoke-runner image pipeline.

## What lands

- `pipelines/tekton/task-resolve-smoke-runner-task-image-digests.yaml`
- pipeline wiring so task-image digest resolution runs after reference-shape checks and before base-image verification
- `task-image-policy.yaml` now records both reference-check and digest-resolution receipt paths
- smoke-runner image README update

## Why

PR #59 added task-image reference checks, but those checks only enforced reference shape when requested. This PR records the resolved digest for each task image using `skopeo inspect`, giving the release lane evidence for Buildah, Syft, Grype, Cosign, Skopeo, and utility task images.

## Still not included

- replacing `REPLACE_WITH_VERIFIED_DIGEST` with known-good digests
- concrete SourceOS/SociOS registry catalog publication implementation
