### PR TITLE
sourceos: add build request intake orchestration

### DIFF
--- a/docs/sourceos/build-request-orchestration-v0.md
+++ b/docs/sourceos/build-request-orchestration-v0.md
@@ -1,0 +1,103 @@
+# SourceOS Build Request Orchestration v0
+
+Status: Draft v0
+Scope: SourceOS build request intake in `SociOS-Linux/socios`
+
+## Purpose
+
+This document defines the first automation boundary for turning a typed SourceOS build request into a `socios` automation receipt.
+
+The goal is to connect `sourceos-spec` build/release concepts to Tekton automation without making `socios` the artifact truth authority.
+
+## Authority boundary
+
+- `SourceOS` owns artifact truth, flavor definitions, release manifests, and durable artifact references.
+- `sourceos-spec` owns the typed object vocabulary for `ContentSpec`, `BuildRequest`, `ReleaseManifest`, `EvidenceBundle`, and `CatalogEntry`.
+- `agentplane` owns execution evidence surfaces when agents validate/run/replay build workflows.
+- `socios` owns automation scaffolds, receipts, and policy checks.
+
+## v0 intake flow
+
+```text
+BuildRequest-style params
+  -> materialize-sourceos-build-request task
+  -> SourceOSBuildRequestMaterializationReceipt
+  -> downstream build / Katello / Smart Proxy / smoke / catalog lanes
+```
+
+## Required fields
+
+The v0 materialization task requires:
+
+- `contentSpecRef`
+- `buildRequestRef`
+- `channel`
+- `architecture`
+- `requestedBy`
+
+The task currently accepts `channel` values:
+
+- `dev`
+- `qa`
+- `prod`
+
+The task currently accepts `architecture` values:
+
+- `x86_64`
+- `aarch64`
+
+## Optional refs
+
+The materialization receipt may carry:
+
+- `overlayRefs`
+- `enrollmentProfileRef`
+- `agentplaneBundleRef`
+- `localExecutionProtocolRef`
+- `remoteExecutionProtocolRef`
+- `katelloProduct`
+- `katelloRepository`
+
+## Agentplane integration
+
+`agentplaneBundleRef` is intentionally carried as metadata. The materialization task does not validate or execute agentplane bundles.
+
+A later execution lane should project this ref into agentplane validation/run/replay artifacts.
+
+## Local and remote protocols
+
+The task defaults:
+
+- local execution protocol: `urn:srcos:contract:workstation-contracts:m2-ipc:v1.0`
+- remote execution protocol: `urn:srcos:protocol:tritrpc:v1`
+
+This preserves the local M2 IPC / remote TriTRPC split established in the upstream specs.
+
+## Output receipt
+
+The task emits:
+
+```text
+.workstation/reports/sourceos/build-request-materialization.json
+```
+
+with kind:
+
+```text
+SourceOSBuildRequestMaterializationReceipt
+```
+
+## Non-goals
+
+- no artifact build yet
+- no release manifest mutation
+- no catalog mutation
+- no automatic agentplane execution
+- no registry or credential handling
+
+## Follow-on work
+
+- add a downstream image-build task that consumes the materialization receipt
+- add a Katello upload/publish task that consumes the materialization receipt
+- add agentplane validation/run/replay projection for build-request execution
+- add catalog publication request generation after build evidence exists

--- a/pipelines/tekton/pipeline-sourceos-build-request-intake.yaml
+++ b/pipelines/tekton/pipeline-sourceos-build-request-intake.yaml
@@ -1,0 +1,76 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: sourceos-build-request-intake
+spec:
+  description: >-
+    Validate and materialize a SourceOS build request into a receipt that downstream
+    build, Katello, Smart Proxy, smoke, and agentplane evidence lanes can consume.
+  params:
+    - name: contentSpecRef
+      type: string
+    - name: buildRequestRef
+      type: string
+    - name: channel
+      type: string
+      default: dev
+    - name: architecture
+      type: string
+      default: x86_64
+    - name: requestedBy
+      type: string
+    - name: overlayRefs
+      type: string
+      default: ""
+    - name: enrollmentProfileRef
+      type: string
+      default: ""
+    - name: agentplaneBundleRef
+      type: string
+      default: ""
+    - name: localExecutionProtocolRef
+      type: string
+      default: urn:srcos:contract:workstation-contracts:m2-ipc:v1.0
+    - name: remoteExecutionProtocolRef
+      type: string
+      default: urn:srcos:protocol:tritrpc:v1
+    - name: katelloProduct
+      type: string
+      default: SourceOS Files
+    - name: katelloRepository
+      type: string
+      default: sourceos-live-iso
+  workspaces:
+    - name: source
+  tasks:
+    - name: materialize-sourceos-build-request
+      taskRef:
+        name: materialize-sourceos-build-request
+      workspaces:
+        - name: source
+          workspace: source
+      params:
+        - name: contentSpecRef
+          value: $(params.contentSpecRef)
+        - name: buildRequestRef
+          value: $(params.buildRequestRef)
+        - name: channel
+          value: $(params.channel)
+        - name: architecture
+          value: $(params.architecture)
+        - name: requestedBy
+          value: $(params.requestedBy)
+        - name: overlayRefs
+          value: $(params.overlayRefs)
+        - name: enrollmentProfileRef
+          value: $(params.enrollmentProfileRef)
+        - name: agentplaneBundleRef
+          value: $(params.agentplaneBundleRef)
+        - name: localExecutionProtocolRef
+          value: $(params.localExecutionProtocolRef)
+        - name: remoteExecutionProtocolRef
+          value: $(params.remoteExecutionProtocolRef)
+        - name: katelloProduct
+          value: $(params.katelloProduct)
+        - name: katelloRepository
+          value: $(params.katelloRepository)

--- a/pipelines/tekton/task-materialize-sourceos-build-request.yaml
+++ b/pipelines/tekton/task-materialize-sourceos-build-request.yaml
@@ -1,0 +1,80 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: materialize-sourceos-build-request
+spec:
+  description: >-
+    Validate SourceOS build request parameters and emit a materialization receipt
+    for downstream SourceOS build automation.
+  params:
+    - name: contentSpecRef
+      type: string
+    - name: buildRequestRef
+      type: string
+    - name: channel
+      type: string
+      default: dev
+    - name: architecture
+      type: string
+      default: x86_64
+    - name: requestedBy
+      type: string
+    - name: overlayRefs
+      type: string
+      default: ""
+    - name: enrollmentProfileRef
+      type: string
+      default: ""
+    - name: agentplaneBundleRef
+      type: string
+      default: ""
+    - name: localExecutionProtocolRef
+      type: string
+      default: urn:srcos:contract:workstation-contracts:m2-ipc:v1.0
+    - name: remoteExecutionProtocolRef
+      type: string
+      default: urn:srcos:protocol:tritrpc:v1
+    - name: katelloProduct
+      type: string
+      default: SourceOS Files
+    - name: katelloRepository
+      type: string
+      default: sourceos-live-iso
+    - name: receiptPath
+      type: string
+      default: .workstation/reports/sourceos/build-request-materialization.json
+  workspaces:
+    - name: source
+      description: Workspace for emitted materialization receipt.
+  steps:
+    - name: materialize
+      image: docker.io/library/busybox:latest
+      workingDir: $(workspaces.source.path)
+      script: |
+        #!/bin/sh
+        set -eu
+        case "$(params.channel)" in dev|qa|prod) ;; *) echo "unsupported channel: $(params.channel)" >&2; exit 2 ;; esac
+        case "$(params.architecture)" in x86_64|aarch64) ;; *) echo "unsupported architecture: $(params.architecture)" >&2; exit 2 ;; esac
+        test -n "$(params.contentSpecRef)"
+        test -n "$(params.buildRequestRef)"
+        test -n "$(params.requestedBy)"
+        mkdir -p "$(dirname "$(params.receiptPath)")"
+        cat > "$(params.receiptPath)" <<JSON
+        {
+          "apiVersion": "socios.sourceos.ai/v0",
+          "kind": "SourceOSBuildRequestMaterializationReceipt",
+          "contentSpecRef": "$(params.contentSpecRef)",
+          "buildRequestRef": "$(params.buildRequestRef)",
+          "channel": "$(params.channel)",
+          "architecture": "$(params.architecture)",
+          "requestedBy": "$(params.requestedBy)",
+          "overlayRefs": "$(params.overlayRefs)",
+          "enrollmentProfileRef": "$(params.enrollmentProfileRef)",
+          "agentplaneBundleRef": "$(params.agentplaneBundleRef)",
+          "localExecutionProtocolRef": "$(params.localExecutionProtocolRef)",
+          "remoteExecutionProtocolRef": "$(params.remoteExecutionProtocolRef)",
+          "katelloProduct": "$(params.katelloProduct)",
+          "katelloRepository": "$(params.katelloRepository)",
+          "receiptPath": "$(params.receiptPath)"
+        }
+        JSON

--- a/policies/sourceos/build-request-policy.yaml
+++ b/policies/sourceos/build-request-policy.yaml
@@ -1,0 +1,37 @@
+apiVersion: socios.sourceos.ai/v0
+kind: SourceOSBuildRequestPolicy
+metadata:
+  name: sourceos-build-request-intake
+spec:
+  authority:
+    artifactTruthRepo: SourceOS-Linux/SourceOS
+    schemaTruthRepo: SourceOS-Linux/sourceos-spec
+    automationRepo: SociOS-Linux/socios
+    executionEvidenceRepo: SocioProphet/agentplane
+  requiredFields:
+    - contentSpecRef
+    - buildRequestRef
+    - channel
+    - architecture
+    - requestedBy
+  optionalFields:
+    - overlayRefs
+    - enrollmentProfileRef
+    - agentplaneBundleRef
+    - localExecutionProtocolRef
+    - remoteExecutionProtocolRef
+    - katelloProduct
+    - katelloRepository
+  allowedChannels:
+    - dev
+    - qa
+    - prod
+  allowedArchitectures:
+    - x86_64
+    - aarch64
+  outputs:
+    receiptPath: .workstation/reports/sourceos/build-request-materialization.json
+  notes:
+    - This policy validates SourceOS build request intake for socios automation.
+    - It does not make socios the source of artifact truth.
+    - SourceOS release manifests remain owned by the artifact truth repo.

--- a/tests/test_sourceos_build_request_shape.py
+++ b/tests/test_sourceos_build_request_shape.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(relpath: str) -> str:
+    return (ROOT / relpath).read_text(encoding="utf-8")
+
+
+class SourceOSBuildRequestShapeTests(unittest.TestCase):
+    def assertContainsAll(self, text: str, needles: list[str]) -> None:  # noqa: N802
+        missing = [needle for needle in needles if needle not in text]
+        self.assertEqual(missing, [], f"missing expected snippets: {missing}")
+
+    def test_build_request_policy_preserves_authority_split(self) -> None:
+        text = read("policies/sourceos/build-request-policy.yaml")
+        self.assertContainsAll(
+            text,
+            [
+                "artifactTruthRepo: SourceOS-Linux/SourceOS",
+                "schemaTruthRepo: SourceOS-Linux/sourceos-spec",
+                "automationRepo: SociOS-Linux/socios",
+                "executionEvidenceRepo: SocioProphet/agentplane",
+                "contentSpecRef",
+                "buildRequestRef",
+            ],
+        )
+
+    def test_materialization_task_emits_receipt_and_protocol_refs(self) -> None:
+        text = read("pipelines/tekton/task-materialize-sourceos-build-request.yaml")
+        self.assertContainsAll(
+            text,
+            [
+                "SourceOSBuildRequestMaterializationReceipt",
+                "contentSpecRef",
+                "buildRequestRef",
+                "agentplaneBundleRef",
+                "urn:srcos:contract:workstation-contracts:m2-ipc:v1.0",
+                "urn:srcos:protocol:tritrpc:v1",
+                "katelloProduct",
+                "katelloRepository",
+            ],
+        )
+
+    def test_intake_pipeline_calls_materialization_task(self) -> None:
+        text = read("pipelines/tekton/pipeline-sourceos-build-request-intake.yaml")
+        self.assertContainsAll(
+            text,
+            [
+                "sourceos-build-request-intake",
+                "materialize-sourceos-build-request",
+                "agentplaneBundleRef",
+                "localExecutionProtocolRef",
+                "remoteExecutionProtocolRef",
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds the first SourceOS build-request intake orchestration lane in `socios`.

This connects `sourceos-spec` BuildRequest-style inputs to `socios` Tekton automation without making `socios` the artifact truth authority.

## What lands

- `policies/sourceos/build-request-policy.yaml`
- `pipelines/tekton/task-materialize-sourceos-build-request.yaml`
- `pipelines/tekton/pipeline-sourceos-build-request-intake.yaml`
- `docs/sourceos/build-request-orchestration-v0.md`
- `tests/test_sourceos_build_request_shape.py`

## Why

The OS build substrate v0 is now upstream. The next layer is actual build orchestration: taking typed SourceOS build request metadata and materializing it into a receipt that downstream build, Katello, Smart Proxy, smoke, agentplane, and catalog lanes can consume.

## Authority boundary

- `SourceOS` remains artifact truth.
- `sourceos-spec` remains schema truth.
- `agentplane` remains execution evidence truth.
- `socios` remains automation and receipt producer.

## Non-goals

- no artifact build yet
- no release manifest mutation
- no catalog mutation
- no automatic agentplane execution
- no registry or credential handling
