### PR TITLE
sourceos: add artifact build receipt lane

### DIFF
--- a/docs/sourceos/artifact-build-receipt-v0.md
+++ b/docs/sourceos/artifact-build-receipt-v0.md
@@ -1,0 +1,73 @@
+# SourceOS Artifact Build Receipt v0
+
+Status: Draft v0
+Scope: SourceOS artifact-build receipt capture in `SociOS-Linux/socios`
+
+## Purpose
+
+This document defines the first downstream build-recording lane after SourceOS build request intake.
+
+The goal is to let `socios` record evidence about produced build artifacts without claiming ownership of SourceOS artifact truth.
+
+## Authority boundary
+
+- `SourceOS` remains artifact truth.
+- `sourceos-spec` remains schema truth for release/evidence/catalog object vocabulary.
+- `agentplane` remains execution evidence truth when builds are agent-executed.
+- `socios` records automation receipts and hashes.
+
+## v0 flow
+
+```text
+SourceOS build request params
+  -> materialize-sourceos-build-request
+  -> SourceOSBuildRequestMaterializationReceipt
+  -> record-sourceos-artifact-build
+  -> SourceOSArtifactBuildReceipt
+```
+
+## Artifact recording semantics
+
+The v0 task accepts an explicit space-separated list of artifact paths.
+
+For each artifact, it records:
+
+- path
+- SHA-256 hash
+- byte size
+
+The task fails if:
+
+- materialization receipt is missing
+- any expected artifact path is missing
+- hash calculation fails
+
+## Output receipt
+
+The task emits:
+
+```text
+.workstation/reports/sourceos/artifact-build-receipt.json
+```
+
+with kind:
+
+```text
+SourceOSArtifactBuildReceipt
+```
+
+## Non-goals
+
+- does not build the artifact itself
+- does not mutate SourceOS release manifests
+- does not upload to Katello
+- does not publish to catalog
+- does not claim release promotion
+
+## Follow-on work
+
+- add a real image-build task for selected SourceOS build systems
+- add Katello upload/publish task consuming this receipt
+- add smoke-runner integration consuming this receipt
+- map this receipt into `sourceos-spec` `EvidenceBundle`
+- project agentplane validation/run/replay refs when applicable

--- a/pipelines/tekton/pipeline-sourceos-build-artifact-receipt.yaml
+++ b/pipelines/tekton/pipeline-sourceos-build-artifact-receipt.yaml
@@ -1,0 +1,74 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: sourceos-build-artifact-receipt
+spec:
+  description: >-
+    Materialize a SourceOS build request and record already-produced build artifacts
+    with hashes and sizes. This pipeline does not mutate SourceOS artifact truth.
+  params:
+    - name: contentSpecRef
+      type: string
+    - name: buildRequestRef
+      type: string
+    - name: requestedBy
+      type: string
+    - name: artifactPaths
+      type: string
+    - name: channel
+      type: string
+      default: dev
+    - name: architecture
+      type: string
+      default: x86_64
+    - name: buildSystemRef
+      type: string
+      default: sourceos://build-system/external
+    - name: overlayRefs
+      type: string
+      default: ""
+    - name: enrollmentProfileRef
+      type: string
+      default: ""
+    - name: agentplaneBundleRef
+      type: string
+      default: ""
+  workspaces:
+    - name: source
+  tasks:
+    - name: materialize-sourceos-build-request
+      taskRef:
+        name: materialize-sourceos-build-request
+      workspaces:
+        - name: source
+          workspace: source
+      params:
+        - name: contentSpecRef
+          value: $(params.contentSpecRef)
+        - name: buildRequestRef
+          value: $(params.buildRequestRef)
+        - name: requestedBy
+          value: $(params.requestedBy)
+        - name: channel
+          value: $(params.channel)
+        - name: architecture
+          value: $(params.architecture)
+        - name: overlayRefs
+          value: $(params.overlayRefs)
+        - name: enrollmentProfileRef
+          value: $(params.enrollmentProfileRef)
+        - name: agentplaneBundleRef
+          value: $(params.agentplaneBundleRef)
+
+    - name: record-sourceos-artifact-build
+      runAfter: [materialize-sourceos-build-request]
+      taskRef:
+        name: record-sourceos-artifact-build
+      workspaces:
+        - name: source
+          workspace: source
+      params:
+        - name: artifactPaths
+          value: $(params.artifactPaths)
+        - name: buildSystemRef
+          value: $(params.buildSystemRef)

--- a/pipelines/tekton/task-record-sourceos-artifact-build.yaml
+++ b/pipelines/tekton/task-record-sourceos-artifact-build.yaml
@@ -1,0 +1,56 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: record-sourceos-artifact-build
+spec:
+  description: >-
+    Record SourceOS build artifact metadata after an external or upstream build step
+    produces artifacts. This task validates expected artifact paths, computes hashes,
+    and emits an artifact-build receipt without claiming artifact truth.
+  params:
+    - name: materializationReceiptPath
+      type: string
+      default: .workstation/reports/sourceos/build-request-materialization.json
+    - name: artifactPaths
+      type: string
+      description: Space-separated artifact paths to record.
+    - name: buildSystemRef
+      type: string
+      default: sourceos://build-system/external
+    - name: receiptPath
+      type: string
+      default: .workstation/reports/sourceos/artifact-build-receipt.json
+  workspaces:
+    - name: source
+      description: Workspace containing materialization receipt and artifacts.
+  steps:
+    - name: record
+      image: docker.io/library/busybox:latest
+      workingDir: $(workspaces.source.path)
+      script: |
+        #!/bin/sh
+        set -eu
+        test -f "$(params.materializationReceiptPath)"
+        mkdir -p "$(dirname "$(params.receiptPath)")"
+        artifacts_json=""
+        for artifact in $(params.artifactPaths); do
+          test -f "$artifact"
+          size="$(wc -c < "$artifact" | tr -d ' ')"
+          hash="$(sha256sum "$artifact" | awk '{print $1}')"
+          entry="{\"path\":\"$artifact\",\"sha256\":\"$hash\",\"sizeBytes\":$size}"
+          if [ -z "$artifacts_json" ]; then
+            artifacts_json="$entry"
+          else
+            artifacts_json="$artifacts_json,$entry"
+          fi
+        done
+        cat > "$(params.receiptPath)" <<JSON
+        {
+          "apiVersion": "socios.sourceos.ai/v0",
+          "kind": "SourceOSArtifactBuildReceipt",
+          "materializationReceiptPath": "$(params.materializationReceiptPath)",
+          "buildSystemRef": "$(params.buildSystemRef)",
+          "artifacts": [${artifacts_json}],
+          "receiptPath": "$(params.receiptPath)"
+        }
+        JSON

--- a/tests/test_sourceos_artifact_build_shape.py
+++ b/tests/test_sourceos_artifact_build_shape.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(relpath: str) -> str:
+    return (ROOT / relpath).read_text(encoding="utf-8")
+
+
+class SourceOSArtifactBuildShapeTests(unittest.TestCase):
+    def assertContainsAll(self, text: str, needles: list[str]) -> None:  # noqa: N802
+        missing = [needle for needle in needles if needle not in text]
+        self.assertEqual(missing, [], f"missing expected snippets: {missing}")
+
+    def test_artifact_receipt_task_records_hashes_and_sizes(self) -> None:
+        text = read("pipelines/tekton/task-record-sourceos-artifact-build.yaml")
+        self.assertContainsAll(
+            text,
+            [
+                "SourceOSArtifactBuildReceipt",
+                "materializationReceiptPath",
+                "artifactPaths",
+                "sha256sum",
+                "sizeBytes",
+                "buildSystemRef",
+            ],
+        )
+
+    def test_artifact_receipt_pipeline_chains_intake_to_recording(self) -> None:
+        text = read("pipelines/tekton/pipeline-sourceos-build-artifact-receipt.yaml")
+        self.assertContainsAll(
+            text,
+            [
+                "sourceos-build-artifact-receipt",
+                "materialize-sourceos-build-request",
+                "record-sourceos-artifact-build",
+                "runAfter: [materialize-sourceos-build-request]",
+                "artifactPaths",
+            ],
+        )
+
+    def test_artifact_receipt_doc_preserves_authority_boundary(self) -> None:
+        text = read("docs/sourceos/artifact-build-receipt-v0.md")
+        self.assertContainsAll(
+            text,
+            [
+                "SourceOS remains artifact truth",
+                "SourceOSArtifactBuildReceipt",
+                "does not mutate SourceOS release manifests",
+                "does not upload to Katello",
+                "does not publish to catalog",
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds the first SourceOS artifact-build receipt lane after build-request intake.

This does not build artifacts yet. It records already-produced artifacts with hashes and sizes, preserving the boundary that `SourceOS` remains artifact truth while `socios` emits automation receipts.

## What lands

- `pipelines/tekton/task-record-sourceos-artifact-build.yaml`
- `pipelines/tekton/pipeline-sourceos-build-artifact-receipt.yaml`
- `docs/sourceos/artifact-build-receipt-v0.md`
- `tests/test_sourceos_artifact_build_shape.py`

## Why

PR #65 introduced build-request materialization. The next downstream seam is to consume that materialization receipt and record artifacts produced by an external or upstream build system.

## Non-goals

- does not build artifacts itself
- does not mutate SourceOS release manifests
- does not upload to Katello
- does not publish to catalog
- does not claim release promotion
