### PR TITLE
sourceos: add Katello artifact publication receipt lane

### DIFF
--- a/docs/sourceos/katello-artifact-publication-v0.md
+++ b/docs/sourceos/katello-artifact-publication-v0.md
@@ -1,0 +1,64 @@
+# SourceOS Katello Artifact Publication v0
+
+Status: Draft v0
+Scope: SourceOS artifact publication receipt flow for Katello-backed artifact repositories
+
+## Purpose
+
+This document defines the first publication seam between SourceOS artifact-build receipts and Katello file repositories.
+
+The goal is to record a publication request/receipt without making publication automatic or moving SourceOS artifact truth into `socios`.
+
+## v0 flow
+
+```text
+BuildRequest-style params
+  -> materialize-sourceos-build-request
+  -> record-sourceos-artifact-build
+  -> publish-sourceos-artifacts-to-katello
+  -> SourceOSKatelloArtifactPublicationReceipt
+```
+
+## Authority boundary
+
+- `SourceOS` remains artifact truth.
+- `socios` emits automation receipts and publication requests.
+- Katello stores lifecycle-managed content after an explicit publication step.
+- Catalog publication remains separate and governed by the catalog authority boundary.
+
+## Current posture
+
+- upload execution is disabled by default
+- the task validates that the artifact-build receipt exists
+- the task records target Katello server/product/repository metadata
+- actual Hammer upload execution is deferred to a Hammer-capable runner image
+
+## Output receipt
+
+The task emits:
+
+```text
+.workstation/reports/sourceos/katello-artifact-publication.json
+```
+
+with kind:
+
+```text
+SourceOSKatelloArtifactPublicationReceipt
+```
+
+## Non-goals
+
+- does not mutate SourceOS release manifests
+- does not publish to catalog
+- does not claim release promotion
+- does not store credentials or secrets
+- does not execute upload unless explicitly enabled
+
+## Follow-on work
+
+- add Hammer-capable runner image policy
+- add actual `hammer repository upload-content` execution path
+- verify uploaded artifact exists in target repository
+- connect publication receipt to lifecycle content-view publish/promote receipts
+- connect publication receipt to catalog publication request generation

--- a/pipelines/tekton/pipeline-sourceos-artifact-katello-publication.yaml
+++ b/pipelines/tekton/pipeline-sourceos-artifact-katello-publication.yaml
@@ -1,0 +1,97 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: sourceos-artifact-katello-publication
+spec:
+  description: >-
+    Materialize a SourceOS build request, record artifact hashes/sizes, and emit a
+    Katello artifact publication receipt. Upload execution is disabled by default.
+  params:
+    - name: contentSpecRef
+      type: string
+    - name: buildRequestRef
+      type: string
+    - name: requestedBy
+      type: string
+    - name: artifactPaths
+      type: string
+    - name: channel
+      type: string
+      default: dev
+    - name: architecture
+      type: string
+      default: x86_64
+    - name: buildSystemRef
+      type: string
+      default: sourceos://build-system/external
+    - name: katelloServerUrl
+      type: string
+      default: https://foreman.example.com
+    - name: organization
+      type: string
+      default: SourceOS
+    - name: product
+      type: string
+      default: SourceOS Files
+    - name: repository
+      type: string
+      default: sourceos-live-iso
+    - name: publishEnabled
+      type: string
+      default: "false"
+  workspaces:
+    - name: source
+  tasks:
+    - name: materialize-sourceos-build-request
+      taskRef:
+        name: materialize-sourceos-build-request
+      workspaces:
+        - name: source
+          workspace: source
+      params:
+        - name: contentSpecRef
+          value: $(params.contentSpecRef)
+        - name: buildRequestRef
+          value: $(params.buildRequestRef)
+        - name: requestedBy
+          value: $(params.requestedBy)
+        - name: channel
+          value: $(params.channel)
+        - name: architecture
+          value: $(params.architecture)
+        - name: katelloProduct
+          value: $(params.product)
+        - name: katelloRepository
+          value: $(params.repository)
+
+    - name: record-sourceos-artifact-build
+      runAfter: [materialize-sourceos-build-request]
+      taskRef:
+        name: record-sourceos-artifact-build
+      workspaces:
+        - name: source
+          workspace: source
+      params:
+        - name: artifactPaths
+          value: $(params.artifactPaths)
+        - name: buildSystemRef
+          value: $(params.buildSystemRef)
+
+    - name: publish-sourceos-artifacts-to-katello
+      runAfter: [record-sourceos-artifact-build]
+      taskRef:
+        name: publish-sourceos-artifacts-to-katello
+      workspaces:
+        - name: source
+          workspace: source
+      params:
+        - name: katelloServerUrl
+          value: $(params.katelloServerUrl)
+        - name: organization
+          value: $(params.organization)
+        - name: product
+          value: $(params.product)
+        - name: repository
+          value: $(params.repository)
+        - name: enabled
+          value: $(params.publishEnabled)

--- a/pipelines/tekton/task-publish-sourceos-artifacts-to-katello.yaml
+++ b/pipelines/tekton/task-publish-sourceos-artifacts-to-katello.yaml
@@ -1,0 +1,61 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: publish-sourceos-artifacts-to-katello
+spec:
+  description: >-
+    Validate SourceOS artifact build receipt inputs and optionally upload artifacts
+    into a Katello file repository. Emits a Katello publication receipt.
+  params:
+    - name: artifactBuildReceiptPath
+      type: string
+      default: .workstation/reports/sourceos/artifact-build-receipt.json
+    - name: katelloServerUrl
+      type: string
+      default: https://foreman.example.com
+    - name: organization
+      type: string
+      default: SourceOS
+    - name: product
+      type: string
+      default: SourceOS Files
+    - name: repository
+      type: string
+      default: sourceos-live-iso
+    - name: enabled
+      type: string
+      default: "false"
+    - name: receiptPath
+      type: string
+      default: .workstation/reports/sourceos/katello-artifact-publication.json
+  workspaces:
+    - name: source
+      description: Workspace containing artifacts and receipts.
+  steps:
+    - name: publish
+      image: docker.io/library/busybox:latest
+      workingDir: $(workspaces.source.path)
+      script: |
+        #!/bin/sh
+        set -eu
+        test -f "$(params.artifactBuildReceiptPath)"
+        mkdir -p "$(dirname "$(params.receiptPath)")"
+        status="skipped"
+        if [ "$(params.enabled)" = "true" ]; then
+          echo "Katello upload execution is intentionally deferred to a Hammer-capable runner image." >&2
+          status="requested"
+        fi
+        cat > "$(params.receiptPath)" <<JSON
+        {
+          "apiVersion": "socios.sourceos.ai/v0",
+          "kind": "SourceOSKatelloArtifactPublicationReceipt",
+          "artifactBuildReceiptPath": "$(params.artifactBuildReceiptPath)",
+          "katelloServerUrl": "$(params.katelloServerUrl)",
+          "organization": "$(params.organization)",
+          "product": "$(params.product)",
+          "repository": "$(params.repository)",
+          "enabled": "$(params.enabled)",
+          "status": "${status}",
+          "receiptPath": "$(params.receiptPath)"
+        }
+        JSON

--- a/tests/test_sourceos_katello_publication_shape.py
+++ b/tests/test_sourceos_katello_publication_shape.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(relpath: str) -> str:
+    return (ROOT / relpath).read_text(encoding="utf-8")
+
+
+class SourceOSKatelloPublicationShapeTests(unittest.TestCase):
+    def assertContainsAll(self, text: str, needles: list[str]) -> None:  # noqa: N802
+        missing = [needle for needle in needles if needle not in text]
+        self.assertEqual(missing, [], f"missing expected snippets: {missing}")
+
+    def test_katello_publication_task_emits_receipt(self) -> None:
+        text = read("pipelines/tekton/task-publish-sourceos-artifacts-to-katello.yaml")
+        self.assertContainsAll(
+            text,
+            [
+                "SourceOSKatelloArtifactPublicationReceipt",
+                "artifactBuildReceiptPath",
+                "katelloServerUrl",
+                "organization",
+                "product",
+                "repository",
+                "enabled",
+            ],
+        )
+
+    def test_katello_publication_pipeline_chains_receipts(self) -> None:
+        text = read("pipelines/tekton/pipeline-sourceos-artifact-katello-publication.yaml")
+        self.assertContainsAll(
+            text,
+            [
+                "sourceos-artifact-katello-publication",
+                "materialize-sourceos-build-request",
+                "record-sourceos-artifact-build",
+                "publish-sourceos-artifacts-to-katello",
+                "runAfter: [record-sourceos-artifact-build]",
+            ],
+        )
+
+    def test_katello_publication_doc_preserves_non_goals(self) -> None:
+        text = read("docs/sourceos/katello-artifact-publication-v0.md")
+        self.assertContainsAll(
+            text,
+            [
+                "SourceOS remains artifact truth",
+                "upload execution is disabled by default",
+                "does not mutate SourceOS release manifests",
+                "does not publish to catalog",
+                "does not store credentials or secrets",
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds the first SourceOS artifact publication receipt lane for Katello-backed artifact repositories.

This consumes the SourceOS artifact-build receipt and emits a Katello publication receipt. Upload execution remains disabled by default.

## What lands

- `pipelines/tekton/task-publish-sourceos-artifacts-to-katello.yaml`
- `pipelines/tekton/pipeline-sourceos-artifact-katello-publication.yaml`
- `docs/sourceos/katello-artifact-publication-v0.md`
- `tests/test_sourceos_katello_publication_shape.py`

## Why

PR #66 added a SourceOS artifact-build receipt lane. This PR adds the next downstream seam: a publication receipt lane for Katello file repositories.

## Safety posture

- upload execution is disabled by default
- actual Hammer upload execution is deferred to a Hammer-capable runner image
- no credentials or secrets are stored
- SourceOS remains artifact truth
- catalog publication remains separate

## Non-goals

- does not mutate SourceOS release manifests
- does not publish to catalog
- does not claim release promotion
