### PR TITLE
sourceos: add Hammer runner image scaffold

### DIFF
--- a/images/sourceos-hammer-runner/Containerfile
+++ b/images/sourceos-hammer-runner/Containerfile
@@ -1,0 +1,19 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+LABEL org.opencontainers.image.title="SourceOS Hammer runner"
+LABEL org.opencontainers.image.description="Minimal runtime scaffold for Foreman/Katello Hammer CLI automation"
+LABEL org.opencontainers.image.source="https://github.com/SociOS-Linux/socios"
+
+RUN microdnf install -y \
+      ruby \
+      rubygems \
+      ca-certificates \
+      jq \
+      coreutils \
+      findutils \
+    && gem install --no-document hammer_cli hammer_cli_foreman hammer_cli_katello \
+    && microdnf clean all
+
+WORKDIR /workspace
+ENTRYPOINT ["hammer"]

--- a/images/sourceos-hammer-runner/README.md
+++ b/images/sourceos-hammer-runner/README.md
@@ -1,0 +1,29 @@
+# SourceOS Hammer runner image
+
+This directory defines a minimal Hammer CLI runner image for SourceOS/Foreman/Katello automation.
+
+## Purpose
+
+The image provides a controlled runtime for future tasks that need Hammer CLI access, including:
+
+- Katello artifact uploads
+- repository verification
+- content-view operations
+- activation/enrollment key inspection
+- Smart Proxy / Capsule inspection
+
+## Current posture
+
+- base image is configurable through `BASE_IMAGE`
+- the Containerfile requires explicit `BASE_IMAGE` input
+- the image policy requires a verified base-image digest before release-grade use
+- no credentials, tokens, activation keys, or server-specific configuration are baked into the image
+- image signing remains optional until cross-stack signing authority is finalized
+
+## Follow-on
+
+The next tranche should add:
+
+- build/SBOM/scan/provenance pipeline for this image
+- digest-resolution workflow matching the smoke-runner image lane
+- Hammer upload task that uses this image and consumes `SourceOSArtifactBuildReceipt`

--- a/images/sourceos-hammer-runner/image-policy.yaml
+++ b/images/sourceos-hammer-runner/image-policy.yaml
@@ -1,0 +1,33 @@
+apiVersion: socios.sourceos.ai/v0
+kind: ImagePolicy
+metadata:
+  name: sourceos-hammer-runner
+spec:
+  imageRef: quay.io/socios/sourceos-hammer-runner:dev
+  baseImage:
+    ref: registry.fedoraproject.org/fedora-minimal
+    digest: REPLACE_WITH_VERIFIED_DIGEST
+    requireDigest: true
+  requiredTools:
+    - hammer
+    - hammer_cli
+    - hammer_cli_foreman
+    - hammer_cli_katello
+    - jq
+  sbom:
+    required: true
+    format: spdx-json
+    outputPath: .workstation/reports/sbom/sourceos-hammer-runner.spdx.json
+  scan:
+    required: true
+    provider: grype
+    failOnSeverity: high
+    outputPath: .workstation/reports/scans/sourceos-hammer-runner-grype.json
+  signing:
+    required: false
+    provider: cosign
+    signaturePath: .workstation/reports/attest/sourceos-hammer-runner.sig
+  notes:
+    - This image is intended for Hammer CLI automation only.
+    - Do not bake credentials, activation keys, tokens, or server-specific configuration into the image.
+    - Replace baseImage.digest with a verified digest before release-grade use.

--- a/pipelines/tekton/pipeline-build-hammer-runner-image.yaml
+++ b/pipelines/tekton/pipeline-build-hammer-runner-image.yaml
@@ -1,0 +1,44 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: sourceos-build-hammer-runner-image
+spec:
+  description: >-
+    Build and optionally publish the SourceOS Hammer runner image used by
+    Foreman/Katello automation lanes.
+  params:
+    - name: imageRef
+      type: string
+      default: quay.io/socios/sourceos-hammer-runner:dev
+    - name: baseImage
+      type: string
+      default: registry.fedoraproject.org/fedora-minimal@sha256:REPLACE_WITH_VERIFIED_DIGEST
+    - name: requirePinnedBase
+      type: string
+      default: "true"
+    - name: push
+      type: string
+      default: "false"
+    - name: builderImage
+      type: string
+      default: quay.io/buildah/stable:latest
+  workspaces:
+    - name: source
+  tasks:
+    - name: build-hammer-runner-image
+      taskRef:
+        name: build-hammer-runner-image
+      workspaces:
+        - name: source
+          workspace: source
+      params:
+        - name: imageRef
+          value: $(params.imageRef)
+        - name: baseImage
+          value: $(params.baseImage)
+        - name: requirePinnedBase
+          value: $(params.requirePinnedBase)
+        - name: push
+          value: $(params.push)
+        - name: builderImage
+          value: $(params.builderImage)

--- a/pipelines/tekton/task-build-hammer-runner-image.yaml
+++ b/pipelines/tekton/task-build-hammer-runner-image.yaml
@@ -1,0 +1,68 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: build-hammer-runner-image
+spec:
+  description: >-
+    Build the SourceOS Hammer runner image from images/sourceos-hammer-runner/Containerfile.
+  params:
+    - name: builderImage
+      type: string
+      description: Image containing buildah.
+      default: quay.io/buildah/stable:latest
+    - name: imageRef
+      type: string
+      default: quay.io/socios/sourceos-hammer-runner:dev
+    - name: baseImage
+      type: string
+      default: registry.fedoraproject.org/fedora-minimal@sha256:REPLACE_WITH_VERIFIED_DIGEST
+    - name: requirePinnedBase
+      type: string
+      default: "true"
+    - name: contextDir
+      type: string
+      default: .
+    - name: containerfile
+      type: string
+      default: images/sourceos-hammer-runner/Containerfile
+    - name: receiptPath
+      type: string
+      default: .workstation/reports/images/sourceos-hammer-runner-build.json
+    - name: push
+      type: string
+      default: "false"
+  workspaces:
+    - name: source
+      description: Checked-out socios repository.
+  steps:
+    - name: build
+      image: $(params.builderImage)
+      workingDir: $(workspaces.source.path)/$(params.contextDir)
+      securityContext:
+        privileged: true
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+        if [[ "$(params.requirePinnedBase)" == "true" && "$(params.baseImage)" != *@sha256:* ]]; then
+          echo "baseImage must be digest-pinned when requirePinnedBase=true" >&2
+          exit 2
+        fi
+        mkdir -p "$(dirname "$(params.receiptPath)")"
+        buildah bud \
+          --build-arg "BASE_IMAGE=$(params.baseImage)" \
+          -f "$(params.containerfile)" \
+          -t "$(params.imageRef)" .
+        if [[ "$(params.push)" == "true" ]]; then
+          buildah push "$(params.imageRef)"
+        fi
+        cat > "$(params.receiptPath)" <<JSON
+        {
+          "apiVersion": "socios.sourceos.ai/v0",
+          "kind": "HammerRunnerImageBuildReceipt",
+          "imageRef": "$(params.imageRef)",
+          "baseImage": "$(params.baseImage)",
+          "requirePinnedBase": "$(params.requirePinnedBase)",
+          "containerfile": "$(params.containerfile)",
+          "pushed": "$(params.push)"
+        }
+        JSON

--- a/tests/test_sourceos_hammer_runner_image_shape.py
+++ b/tests/test_sourceos_hammer_runner_image_shape.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(relpath: str) -> str:
+    return (ROOT / relpath).read_text(encoding="utf-8")
+
+
+class SourceOSHammerRunnerImageShapeTests(unittest.TestCase):
+    def assertContainsAll(self, text: str, needles: list[str]) -> None:  # noqa: N802
+        missing = [needle for needle in needles if needle not in text]
+        self.assertEqual(missing, [], f"missing expected snippets: {missing}")
+
+    def test_containerfile_has_hammer_runtime_and_no_static_secret_material(self) -> None:
+        text = read("images/sourceos-hammer-runner/Containerfile")
+        self.assertContainsAll(
+            text,
+            [
+                "ARG BASE_IMAGE",
+                "hammer_cli",
+                "hammer_cli_foreman",
+                "hammer_cli_katello",
+                "ENTRYPOINT [\"hammer\"]",
+            ],
+        )
+        self.assertNotIn("password", text.lower())
+        self.assertNotIn("token", text.lower())
+
+    def test_image_policy_requires_digest_and_documents_no_credentials(self) -> None:
+        text = read("images/sourceos-hammer-runner/image-policy.yaml")
+        self.assertContainsAll(
+            text,
+            [
+                "requireDigest: true",
+                "REPLACE_WITH_VERIFIED_DIGEST",
+                "hammer_cli_katello",
+                "Do not bake credentials",
+            ],
+        )
+
+    def test_build_task_records_hammer_runner_image_receipt(self) -> None:
+        text = read("pipelines/tekton/task-build-hammer-runner-image.yaml")
+        self.assertContainsAll(
+            text,
+            [
+                "HammerRunnerImageBuildReceipt",
+                "BASE_IMAGE=$(params.baseImage)",
+                "requirePinnedBase",
+                "buildah bud",
+            ],
+        )
+
+    def test_build_pipeline_calls_hammer_runner_build_task(self) -> None:
+        text = read("pipelines/tekton/pipeline-build-hammer-runner-image.yaml")
+        self.assertContainsAll(
+            text,
+            [
+                "sourceos-build-hammer-runner-image",
+                "build-hammer-runner-image",
+                "baseImage",
+                "requirePinnedBase",
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a minimal Hammer CLI runner image scaffold for future Foreman/Katello automation lanes.

## What lands

- `images/sourceos-hammer-runner/Containerfile`
- `images/sourceos-hammer-runner/image-policy.yaml`
- `images/sourceos-hammer-runner/README.md`
- `pipelines/tekton/task-build-hammer-runner-image.yaml`
- `pipelines/tekton/pipeline-build-hammer-runner-image.yaml`
- `tests/test_sourceos_hammer_runner_image_shape.py`

## Why

The Katello artifact publication lane intentionally deferred actual Hammer upload execution to a Hammer-capable runner image. This PR adds that image scaffold and build receipt path without baking credentials or enabling uploads.

## Safety posture

- no credentials, tokens, activation keys, or server-specific configuration are baked into the image
- base image must be supplied explicitly
- release-grade use requires a verified base-image digest
- image signing remains deferred to the existing cross-stack signing authority work

## Non-goals

- no artifact upload execution yet
- no Katello credential handling
- no release promotion
