### PR TITLE
sourceos: add gated Katello Hammer upload lane

### DIFF
--- a/docs/sourceos/katello-hammer-upload-v0.md
+++ b/docs/sourceos/katello-hammer-upload-v0.md
@@ -1,0 +1,62 @@
+# SourceOS Katello Hammer Upload v0
+
+Status: Draft v0
+Scope: Gated Hammer CLI upload lane for SourceOS artifacts
+
+## Purpose
+
+This document defines the first executable upload seam for SourceOS artifacts into Katello-backed repositories.
+
+The lane consumes a `SourceOSArtifactBuildReceipt`, uses the SourceOS Hammer runner image, and emits upload plus verification receipts.
+
+## v0 flow
+
+```text
+BuildRequest-style params
+  -> materialize-sourceos-build-request
+  -> record-sourceos-artifact-build
+  -> publish-sourceos-artifacts-to-katello
+  -> upload-sourceos-artifacts-with-hammer
+  -> SourceOSKatelloHammerUploadReceipt
+  -> SourceOSKatelloHammerUploadVerificationReceipt
+```
+
+## Safety posture
+
+- upload execution is disabled by default
+- the task requires an existing artifact-build receipt
+- the task requires explicit artifact paths
+- the task uses a dedicated Hammer runner image
+- no credentials or secrets are stored in repo
+- SourceOS remains artifact truth
+- catalog publication remains separate
+
+## Execution gate
+
+Actual upload is controlled by:
+
+```text
+uploadEnabled=true
+```
+
+If upload is disabled, the task still validates local artifact paths and emits skipped receipts.
+
+## Verification posture
+
+The v0 verification step records repository info after upload when enabled.
+
+It does not yet assert that every uploaded artifact appears in repository content listings. That should be added once stable Hammer output for file content listing is validated.
+
+## Non-goals
+
+- no SourceOS release manifest mutation
+- no catalog publication
+- no credential handling
+- no release promotion
+
+## Follow-on work
+
+- add Hammer-capable runner image digest/SBOM/scan policy hardening
+- verify uploaded artifact names/checksums against Katello repository content listings
+- connect upload receipt to content-view publish/promote receipts
+- connect upload receipt to catalog publication request generation

--- a/pipelines/tekton/pipeline-sourceos-katello-hammer-upload.yaml
+++ b/pipelines/tekton/pipeline-sourceos-katello-hammer-upload.yaml
@@ -1,0 +1,126 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: sourceos-katello-hammer-upload
+spec:
+  description: >-
+    Materialize a SourceOS build request, record artifact metadata, emit Katello
+    publication receipt, and optionally upload artifacts using Hammer CLI.
+  params:
+    - name: contentSpecRef
+      type: string
+    - name: buildRequestRef
+      type: string
+    - name: requestedBy
+      type: string
+    - name: artifactPaths
+      type: string
+    - name: channel
+      type: string
+      default: dev
+    - name: architecture
+      type: string
+      default: x86_64
+    - name: buildSystemRef
+      type: string
+      default: sourceos://build-system/external
+    - name: hammerRunnerImage
+      type: string
+      default: quay.io/socios/sourceos-hammer-runner:dev
+    - name: katelloServerUrl
+      type: string
+      default: https://foreman.example.com
+    - name: organization
+      type: string
+      default: SourceOS
+    - name: product
+      type: string
+      default: SourceOS Files
+    - name: repository
+      type: string
+      default: sourceos-live-iso
+    - name: publishEnabled
+      type: string
+      default: "false"
+    - name: uploadEnabled
+      type: string
+      default: "false"
+  workspaces:
+    - name: source
+  tasks:
+    - name: materialize-sourceos-build-request
+      taskRef:
+        name: materialize-sourceos-build-request
+      workspaces:
+        - name: source
+          workspace: source
+      params:
+        - name: contentSpecRef
+          value: $(params.contentSpecRef)
+        - name: buildRequestRef
+          value: $(params.buildRequestRef)
+        - name: requestedBy
+          value: $(params.requestedBy)
+        - name: channel
+          value: $(params.channel)
+        - name: architecture
+          value: $(params.architecture)
+        - name: katelloProduct
+          value: $(params.product)
+        - name: katelloRepository
+          value: $(params.repository)
+
+    - name: record-sourceos-artifact-build
+      runAfter: [materialize-sourceos-build-request]
+      taskRef:
+        name: record-sourceos-artifact-build
+      workspaces:
+        - name: source
+          workspace: source
+      params:
+        - name: artifactPaths
+          value: $(params.artifactPaths)
+        - name: buildSystemRef
+          value: $(params.buildSystemRef)
+
+    - name: publish-sourceos-artifacts-to-katello
+      runAfter: [record-sourceos-artifact-build]
+      taskRef:
+        name: publish-sourceos-artifacts-to-katello
+      workspaces:
+        - name: source
+          workspace: source
+      params:
+        - name: katelloServerUrl
+          value: $(params.katelloServerUrl)
+        - name: organization
+          value: $(params.organization)
+        - name: product
+          value: $(params.product)
+        - name: repository
+          value: $(params.repository)
+        - name: enabled
+          value: $(params.publishEnabled)
+
+    - name: upload-sourceos-artifacts-with-hammer
+      runAfter: [publish-sourceos-artifacts-to-katello]
+      taskRef:
+        name: upload-sourceos-artifacts-with-hammer
+      workspaces:
+        - name: source
+          workspace: source
+      params:
+        - name: hammerRunnerImage
+          value: $(params.hammerRunnerImage)
+        - name: artifactPaths
+          value: $(params.artifactPaths)
+        - name: katelloServerUrl
+          value: $(params.katelloServerUrl)
+        - name: organization
+          value: $(params.organization)
+        - name: product
+          value: $(params.product)
+        - name: repository
+          value: $(params.repository)
+        - name: enabled
+          value: $(params.uploadEnabled)

--- a/pipelines/tekton/task-upload-sourceos-artifacts-with-hammer.yaml
+++ b/pipelines/tekton/task-upload-sourceos-artifacts-with-hammer.yaml
@@ -1,0 +1,104 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: upload-sourceos-artifacts-with-hammer
+spec:
+  description: >-
+    Upload SourceOS artifacts to a Katello repository using Hammer CLI when
+    explicitly enabled. Emits upload and verification receipts.
+  params:
+    - name: hammerRunnerImage
+      type: string
+      default: quay.io/socios/sourceos-hammer-runner:dev
+    - name: artifactBuildReceiptPath
+      type: string
+      default: .workstation/reports/sourceos/artifact-build-receipt.json
+    - name: katelloServerUrl
+      type: string
+      default: https://foreman.example.com
+    - name: organization
+      type: string
+      default: SourceOS
+    - name: product
+      type: string
+      default: SourceOS Files
+    - name: repository
+      type: string
+      default: sourceos-live-iso
+    - name: artifactPaths
+      type: string
+      description: Space-separated artifact paths to upload and verify.
+    - name: enabled
+      type: string
+      default: "false"
+    - name: uploadReceiptPath
+      type: string
+      default: .workstation/reports/sourceos/katello-hammer-upload.json
+    - name: verificationReceiptPath
+      type: string
+      default: .workstation/reports/sourceos/katello-hammer-upload-verification.json
+  workspaces:
+    - name: source
+      description: Workspace containing artifacts and receipts.
+  steps:
+    - name: upload
+      image: $(params.hammerRunnerImage)
+      workingDir: $(workspaces.source.path)
+      script: |
+        #!/usr/bin/env sh
+        set -eu
+        test -f "$(params.artifactBuildReceiptPath)"
+        mkdir -p "$(dirname "$(params.uploadReceiptPath)")"
+        mkdir -p "$(dirname "$(params.verificationReceiptPath)")"
+        status="skipped"
+        uploaded_json=""
+        verified_json=""
+        if [ "$(params.enabled)" = "true" ]; then
+          for artifact in $(params.artifactPaths); do
+            test -f "$artifact"
+            hammer --server "$(params.katelloServerUrl)" repository upload-content \
+              --organization "$(params.organization)" \
+              --product "$(params.product)" \
+              --name "$(params.repository)" \
+              --path "$artifact"
+            entry="{\"path\":\"$artifact\",\"status\":\"requested\"}"
+            if [ -z "$uploaded_json" ]; then uploaded_json="$entry"; else uploaded_json="$uploaded_json,$entry"; fi
+          done
+          status="uploaded"
+          hammer --server "$(params.katelloServerUrl)" repository info \
+            --organization "$(params.organization)" \
+            --product "$(params.product)" \
+            --name "$(params.repository)" > .workstation/reports/sourceos/katello-hammer-repository-info.txt
+          verified_json="{\"repositoryInfoPath\":\".workstation/reports/sourceos/katello-hammer-repository-info.txt\"}"
+        else
+          for artifact in $(params.artifactPaths); do
+            test -f "$artifact"
+            entry="{\"path\":\"$artifact\",\"status\":\"skipped\"}"
+            if [ -z "$uploaded_json" ]; then uploaded_json="$entry"; else uploaded_json="$uploaded_json,$entry"; fi
+          done
+          verified_json="{\"status\":\"skipped\"}"
+        fi
+        cat > "$(params.uploadReceiptPath)" <<JSON
+        {
+          "apiVersion": "socios.sourceos.ai/v0",
+          "kind": "SourceOSKatelloHammerUploadReceipt",
+          "artifactBuildReceiptPath": "$(params.artifactBuildReceiptPath)",
+          "katelloServerUrl": "$(params.katelloServerUrl)",
+          "organization": "$(params.organization)",
+          "product": "$(params.product)",
+          "repository": "$(params.repository)",
+          "enabled": "$(params.enabled)",
+          "status": "${status}",
+          "artifacts": [${uploaded_json}],
+          "receiptPath": "$(params.uploadReceiptPath)"
+        }
+        JSON
+        cat > "$(params.verificationReceiptPath)" <<JSON
+        {
+          "apiVersion": "socios.sourceos.ai/v0",
+          "kind": "SourceOSKatelloHammerUploadVerificationReceipt",
+          "uploadReceiptPath": "$(params.uploadReceiptPath)",
+          "verification": ${verified_json},
+          "receiptPath": "$(params.verificationReceiptPath)"
+        }
+        JSON

--- a/tests/test_sourceos_katello_hammer_upload_shape.py
+++ b/tests/test_sourceos_katello_hammer_upload_shape.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(relpath: str) -> str:
+    return (ROOT / relpath).read_text(encoding="utf-8")
+
+
+class SourceOSKatelloHammerUploadShapeTests(unittest.TestCase):
+    def assertContainsAll(self, text: str, needles: list[str]) -> None:  # noqa: N802
+        missing = [needle for needle in needles if needle not in text]
+        self.assertEqual(missing, [], f"missing expected snippets: {missing}")
+
+    def test_hammer_upload_task_is_gated_and_receipted(self) -> None:
+        text = read("pipelines/tekton/task-upload-sourceos-artifacts-with-hammer.yaml")
+        self.assertContainsAll(
+            text,
+            [
+                "upload-sourceos-artifacts-with-hammer",
+                "SourceOSKatelloHammerUploadReceipt",
+                "SourceOSKatelloHammerUploadVerificationReceipt",
+                "artifactBuildReceiptPath",
+                "hammerRunnerImage",
+                "repository upload-content",
+                "enabled",
+            ],
+        )
+
+    def test_hammer_upload_pipeline_chains_publication_to_upload(self) -> None:
+        text = read("pipelines/tekton/pipeline-sourceos-katello-hammer-upload.yaml")
+        self.assertContainsAll(
+            text,
+            [
+                "sourceos-katello-hammer-upload",
+                "materialize-sourceos-build-request",
+                "record-sourceos-artifact-build",
+                "publish-sourceos-artifacts-to-katello",
+                "upload-sourceos-artifacts-with-hammer",
+                "runAfter: [publish-sourceos-artifacts-to-katello]",
+            ],
+        )
+
+    def test_hammer_upload_doc_preserves_safety_posture(self) -> None:
+        text = read("docs/sourceos/katello-hammer-upload-v0.md")
+        self.assertContainsAll(
+            text,
+            [
+                "upload execution is disabled by default",
+                "no credentials or secrets are stored in repo",
+                "SourceOS remains artifact truth",
+                "catalog publication remains separate",
+                "uploadEnabled=true",
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a gated Hammer CLI upload lane for SourceOS artifacts into Katello-backed repositories.

This consumes the SourceOS artifact-build receipt, uses the dedicated SourceOS Hammer runner image, and emits upload plus verification receipts.

## What lands

- `pipelines/tekton/task-upload-sourceos-artifacts-with-hammer.yaml`
- `pipelines/tekton/pipeline-sourceos-katello-hammer-upload.yaml`
- `docs/sourceos/katello-hammer-upload-v0.md`
- `tests/test_sourceos_katello_hammer_upload_shape.py`

## Safety posture

- upload execution is disabled by default
- upload requires `uploadEnabled=true`
- no credentials or secrets are stored
- SourceOS remains artifact truth
- catalog publication remains separate

## Non-goals

- no SourceOS release manifest mutation
- no catalog publication
- no credential handling
- no release promotion
