### PR TITLE
sourceos: verify Katello uploaded artifact names

### DIFF
--- a/docs/sourceos/katello-hammer-upload-v0.md
+++ b/docs/sourceos/katello-hammer-upload-v0.md
@@ -18,7 +18,7 @@ BuildRequest-style params
   -> publish-sourceos-artifacts-to-katello
   -> upload-sourceos-artifacts-with-hammer
   -> SourceOSKatelloHammerUploadReceipt
-  -> SourceOSKatelloHammerUploadVerificationReceipt
+  -> SourceOSKatelloUploadedArtifactVerificationReceipt
 ```
 
 ## Safety posture
@@ -43,9 +43,15 @@ If upload is disabled, the task still validates local artifact paths and emits s
 
 ## Verification posture
 
-The v0 verification step records repository info after upload when enabled.
+When upload is enabled, the task now captures `hammer file list` output for the target organization/product/repository and invokes `tools/verify-katello-uploaded-artifacts`.
 
-It does not yet assert that every uploaded artifact appears in repository content listings. That should be added once stable Hammer output for file content listing is validated.
+The verifier checks that every expected artifact basename appears in the captured listing output and emits:
+
+```text
+SourceOSKatelloUploadedArtifactVerificationReceipt
+```
+
+This is still intentionally conservative. It verifies artifact-name visibility, not checksum parity inside Katello. Checksum-level verification should be added after stable Hammer file checksum output is validated in the target Foreman/Katello version.
 
 ## Non-goals
 
@@ -53,10 +59,11 @@ It does not yet assert that every uploaded artifact appears in repository conten
 - no catalog publication
 - no credential handling
 - no release promotion
+- no checksum-level Katello content verification yet
 
 ## Follow-on work
 
 - add Hammer-capable runner image digest/SBOM/scan policy hardening
-- verify uploaded artifact names/checksums against Katello repository content listings
+- add checksum-level verification against Katello file listing/details when stable output is validated
 - connect upload receipt to content-view publish/promote receipts
 - connect upload receipt to catalog publication request generation

--- a/images/sourceos-hammer-runner/Containerfile
+++ b/images/sourceos-hammer-runner/Containerfile
@@ -8,6 +8,7 @@ LABEL org.opencontainers.image.source="https://github.com/SociOS-Linux/socios"
 RUN microdnf install -y \
       ruby \
       rubygems \
+      python3 \
       ca-certificates \
       jq \
       coreutils \

--- a/pipelines/tekton/task-upload-sourceos-artifacts-with-hammer.yaml
+++ b/pipelines/tekton/task-upload-sourceos-artifacts-with-hammer.yaml
@@ -37,6 +37,9 @@ spec:
     - name: verificationReceiptPath
       type: string
       default: .workstation/reports/sourceos/katello-hammer-upload-verification.json
+    - name: repositoryListingPath
+      type: string
+      default: .workstation/reports/sourceos/katello-hammer-file-list.txt
   workspaces:
     - name: source
       description: Workspace containing artifacts and receipts.
@@ -48,14 +51,17 @@ spec:
         #!/usr/bin/env sh
         set -eu
         test -f "$(params.artifactBuildReceiptPath)"
+        test -f ./tools/verify-katello-uploaded-artifacts
         mkdir -p "$(dirname "$(params.uploadReceiptPath)")"
         mkdir -p "$(dirname "$(params.verificationReceiptPath)")"
+        mkdir -p "$(dirname "$(params.repositoryListingPath)")"
         status="skipped"
         uploaded_json=""
-        verified_json=""
+        artifact_args=""
         if [ "$(params.enabled)" = "true" ]; then
           for artifact in $(params.artifactPaths); do
             test -f "$artifact"
+            artifact_args="$artifact_args --artifact $artifact"
             hammer --server "$(params.katelloServerUrl)" repository upload-content \
               --organization "$(params.organization)" \
               --product "$(params.product)" \
@@ -65,18 +71,29 @@ spec:
             if [ -z "$uploaded_json" ]; then uploaded_json="$entry"; else uploaded_json="$uploaded_json,$entry"; fi
           done
           status="uploaded"
-          hammer --server "$(params.katelloServerUrl)" repository info \
+          hammer --server "$(params.katelloServerUrl)" file list \
             --organization "$(params.organization)" \
             --product "$(params.product)" \
-            --name "$(params.repository)" > .workstation/reports/sourceos/katello-hammer-repository-info.txt
-          verified_json="{\"repositoryInfoPath\":\".workstation/reports/sourceos/katello-hammer-repository-info.txt\"}"
+            --repository "$(params.repository)" > "$(params.repositoryListingPath)"
+          python3 ./tools/verify-katello-uploaded-artifacts \
+            --listing "$(params.repositoryListingPath)" \
+            $artifact_args \
+            --receipt "$(params.verificationReceiptPath)"
         else
           for artifact in $(params.artifactPaths); do
             test -f "$artifact"
             entry="{\"path\":\"$artifact\",\"status\":\"skipped\"}"
             if [ -z "$uploaded_json" ]; then uploaded_json="$entry"; else uploaded_json="$uploaded_json,$entry"; fi
           done
-          verified_json="{\"status\":\"skipped\"}"
+          cat > "$(params.verificationReceiptPath)" <<JSON
+        {
+          "apiVersion": "socios.sourceos.ai/v0",
+          "kind": "SourceOSKatelloUploadedArtifactVerificationReceipt",
+          "status": "skipped",
+          "listingPath": "$(params.repositoryListingPath)",
+          "receiptPath": "$(params.verificationReceiptPath)"
+        }
+        JSON
         fi
         cat > "$(params.uploadReceiptPath)" <<JSON
         {
@@ -90,15 +107,8 @@ spec:
           "enabled": "$(params.enabled)",
           "status": "${status}",
           "artifacts": [${uploaded_json}],
+          "repositoryListingPath": "$(params.repositoryListingPath)",
+          "verificationReceiptPath": "$(params.verificationReceiptPath)",
           "receiptPath": "$(params.uploadReceiptPath)"
-        }
-        JSON
-        cat > "$(params.verificationReceiptPath)" <<JSON
-        {
-          "apiVersion": "socios.sourceos.ai/v0",
-          "kind": "SourceOSKatelloHammerUploadVerificationReceipt",
-          "uploadReceiptPath": "$(params.uploadReceiptPath)",
-          "verification": ${verified_json},
-          "receiptPath": "$(params.verificationReceiptPath)"
         }
         JSON

--- a/tests/test_sourceos_katello_hammer_upload_shape.py
+++ b/tests/test_sourceos_katello_hammer_upload_shape.py
@@ -23,10 +23,13 @@ class SourceOSKatelloHammerUploadShapeTests(unittest.TestCase):
             [
                 "upload-sourceos-artifacts-with-hammer",
                 "SourceOSKatelloHammerUploadReceipt",
-                "SourceOSKatelloHammerUploadVerificationReceipt",
+                "SourceOSKatelloUploadedArtifactVerificationReceipt",
                 "artifactBuildReceiptPath",
                 "hammerRunnerImage",
                 "repository upload-content",
+                "file list",
+                "repositoryListingPath",
+                "verify-katello-uploaded-artifacts",
                 "enabled",
             ],
         )
@@ -45,7 +48,7 @@ class SourceOSKatelloHammerUploadShapeTests(unittest.TestCase):
             ],
         )
 
-    def test_hammer_upload_doc_preserves_safety_posture(self) -> None:
+    def test_hammer_upload_doc_preserves_safety_posture_and_verification_scope(self) -> None:
         text = read("docs/sourceos/katello-hammer-upload-v0.md")
         self.assertContainsAll(
             text,
@@ -55,6 +58,8 @@ class SourceOSKatelloHammerUploadShapeTests(unittest.TestCase):
                 "SourceOS remains artifact truth",
                 "catalog publication remains separate",
                 "uploadEnabled=true",
+                "SourceOSKatelloUploadedArtifactVerificationReceipt",
+                "checksum-level Katello content verification",
             ],
         )
 

--- a/tests/test_verify_katello_uploaded_artifacts.py
+++ b/tests/test_verify_katello_uploaded_artifacts.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+TOOL = ROOT / "tools" / "verify-katello-uploaded-artifacts"
+
+spec = importlib.util.spec_from_file_location("verify_katello_uploaded_artifacts", TOOL)
+assert spec and spec.loader
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+
+class VerifyKatelloUploadedArtifactsTests(unittest.TestCase):
+    def test_verify_passes_when_basenames_are_present(self) -> None:
+        listing = "sourceos-live.iso\nsourceos-config.tar\n"
+        result = module.verify(listing, ["dist/sourceos-live.iso", "out/sourceos-config.tar"])
+        self.assertEqual(result["status"], "pass")
+        self.assertEqual(result["missing"], [])
+
+    def test_verify_reports_missing_basename(self) -> None:
+        listing = "sourceos-live.iso\n"
+        result = module.verify(listing, ["dist/sourceos-live.iso", "out/sourceos-config.tar"])
+        self.assertEqual(result["status"], "fail")
+        self.assertEqual(result["missing"], ["sourceos-config.tar"])
+
+    def test_verify_ignores_empty_artifact_paths(self) -> None:
+        listing = "sourceos-live.iso\n"
+        result = module.verify(listing, ["dist/sourceos-live.iso", ""])
+        self.assertEqual(result["expected"], ["sourceos-live.iso"])
+        self.assertEqual(result["status"], "pass")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/verify-katello-uploaded-artifacts
+++ b/tools/verify-katello-uploaded-artifacts
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Verify expected artifact basenames appear in Hammer/Katello content listing output.
+
+This helper is intentionally simple. It reads a text/CSV listing captured from
+Hammer and verifies that every expected artifact basename is visible somewhere in
+that listing. It emits a JSON receipt suitable for downstream evidence bundles.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def die(msg: str) -> None:
+    print(f"[verify-katello-uploaded-artifacts] ERROR: {msg}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def verify(listing_text: str, artifact_paths: list[str]) -> dict:
+    expected = [Path(path).name for path in artifact_paths if path]
+    missing = [name for name in expected if name not in listing_text]
+    return {
+        "expected": expected,
+        "missing": missing,
+        "status": "pass" if not missing else "fail",
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(prog="verify-katello-uploaded-artifacts")
+    parser.add_argument("--listing", required=True, help="Path to captured Hammer/Katello listing output")
+    parser.add_argument("--artifact", action="append", default=[], help="Expected artifact path; repeatable")
+    parser.add_argument("--receipt", required=True, help="Output receipt path")
+    args = parser.parse_args()
+
+    listing_path = Path(args.listing)
+    if not listing_path.exists():
+        die(f"listing file not found: {listing_path}")
+    if not args.artifact:
+        die("at least one --artifact is required")
+
+    result = verify(listing_path.read_text(encoding="utf-8", errors="replace"), args.artifact)
+    receipt = {
+        "apiVersion": "socios.sourceos.ai/v0",
+        "kind": "SourceOSKatelloUploadedArtifactVerificationReceipt",
+        "listingPath": str(listing_path),
+        "artifacts": args.artifact,
+        **result,
+        "receiptPath": args.receipt,
+    }
+
+    receipt_path = Path(args.receipt)
+    receipt_path.parent.mkdir(parents=True, exist_ok=True)
+    receipt_path.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if result["missing"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds post-upload artifact-name verification for the gated SourceOS Katello Hammer upload lane.

## What lands

- `tools/verify-katello-uploaded-artifacts`
- `tests/test_verify_katello_uploaded_artifacts.py`
- update Hammer runner image to include Python runtime for the verifier helper
- update `task-upload-sourceos-artifacts-with-hammer.yaml` to capture `hammer file list` output and invoke the verifier
- update `docs/sourceos/katello-hammer-upload-v0.md`
- update `tests/test_sourceos_katello_hammer_upload_shape.py`

## Why

PR #69 added gated Hammer upload execution and receipts. This PR strengthens the verification seam by checking that each expected artifact basename appears in captured Katello file listing output after upload.

## Safety posture

- upload remains disabled by default
- verification only runs after explicitly enabled upload
- no credentials or secrets are stored
- SourceOS remains artifact truth
- catalog publication remains separate

## Still not included

- checksum-level Katello content verification
- SourceOS release manifest mutation
- catalog publication
