### PR TITLE
sourceos: add optional Katello upload checksum verification

### DIFF
--- a/docs/sourceos/katello-hammer-upload-v0.md
+++ b/docs/sourceos/katello-hammer-upload-v0.md
@@ -31,7 +31,7 @@ BuildRequest-style params
 - SourceOS remains artifact truth
 - catalog publication remains separate
 
-## Execution gate
+## Execution gates
 
 Actual upload is controlled by:
 
@@ -39,19 +39,27 @@ Actual upload is controlled by:
 uploadEnabled=true
 ```
 
+Optional checksum-level verification is controlled by:
+
+```text
+verifyChecksums=true
+```
+
 If upload is disabled, the task still validates local artifact paths and emits skipped receipts.
 
 ## Verification posture
 
-When upload is enabled, the task now captures `hammer file list` output for the target organization/product/repository and invokes `tools/verify-katello-uploaded-artifacts`.
+When upload is enabled, the task captures `hammer file list` output for the target organization/product/repository and invokes `tools/verify-katello-uploaded-artifacts`.
 
-The verifier checks that every expected artifact basename appears in the captured listing output and emits:
+The verifier always checks that every expected artifact basename appears in the captured listing output and emits:
 
 ```text
 SourceOSKatelloUploadedArtifactVerificationReceipt
 ```
 
-This is still intentionally conservative. It verifies artifact-name visibility, not checksum parity inside Katello. Checksum-level verification should be added after stable Hammer file checksum output is validated in the target Foreman/Katello version.
+When `verifyChecksums=true`, the verifier additionally computes local SHA-256 hashes and requires those hash values to appear in the captured listing output.
+
+This is intentionally gated because checksum field availability may vary by target Foreman/Katello version and file listing configuration.
 
 ## Non-goals
 
@@ -59,11 +67,11 @@ This is still intentionally conservative. It verifies artifact-name visibility, 
 - no catalog publication
 - no credential handling
 - no release promotion
-- no checksum-level Katello content verification yet
+- no automatic checksum verification unless explicitly enabled
 
 ## Follow-on work
 
 - add Hammer-capable runner image digest/SBOM/scan policy hardening
-- add checksum-level verification against Katello file listing/details when stable output is validated
+- validate checksum output against the exact target Foreman/Katello version
 - connect upload receipt to content-view publish/promote receipts
 - connect upload receipt to catalog publication request generation

--- a/pipelines/tekton/task-upload-sourceos-artifacts-with-hammer.yaml
+++ b/pipelines/tekton/task-upload-sourceos-artifacts-with-hammer.yaml
@@ -31,6 +31,10 @@ spec:
     - name: enabled
       type: string
       default: "false"
+    - name: verifyChecksums
+      type: string
+      description: Require local SHA-256 values to appear in the Katello file listing output.
+      default: "false"
     - name: uploadReceiptPath
       type: string
       default: .workstation/reports/sourceos/katello-hammer-upload.json
@@ -58,6 +62,10 @@ spec:
         status="skipped"
         uploaded_json=""
         artifact_args=""
+        checksum_arg=""
+        if [ "$(params.verifyChecksums)" = "true" ]; then
+          checksum_arg="--verify-checksums"
+        fi
         if [ "$(params.enabled)" = "true" ]; then
           for artifact in $(params.artifactPaths); do
             test -f "$artifact"
@@ -78,6 +86,7 @@ spec:
           python3 ./tools/verify-katello-uploaded-artifacts \
             --listing "$(params.repositoryListingPath)" \
             $artifact_args \
+            $checksum_arg \
             --receipt "$(params.verificationReceiptPath)"
         else
           for artifact in $(params.artifactPaths); do
@@ -90,6 +99,7 @@ spec:
           "apiVersion": "socios.sourceos.ai/v0",
           "kind": "SourceOSKatelloUploadedArtifactVerificationReceipt",
           "status": "skipped",
+          "verifyChecksums": "$(params.verifyChecksums)",
           "listingPath": "$(params.repositoryListingPath)",
           "receiptPath": "$(params.verificationReceiptPath)"
         }
@@ -105,6 +115,7 @@ spec:
           "product": "$(params.product)",
           "repository": "$(params.repository)",
           "enabled": "$(params.enabled)",
+          "verifyChecksums": "$(params.verifyChecksums)",
           "status": "${status}",
           "artifacts": [${uploaded_json}],
           "repositoryListingPath": "$(params.repositoryListingPath)",

--- a/tests/test_sourceos_katello_hammer_upload_shape.py
+++ b/tests/test_sourceos_katello_hammer_upload_shape.py
@@ -30,6 +30,8 @@ class SourceOSKatelloHammerUploadShapeTests(unittest.TestCase):
                 "file list",
                 "repositoryListingPath",
                 "verify-katello-uploaded-artifacts",
+                "verifyChecksums",
+                "--verify-checksums",
                 "enabled",
             ],
         )
@@ -58,8 +60,9 @@ class SourceOSKatelloHammerUploadShapeTests(unittest.TestCase):
                 "SourceOS remains artifact truth",
                 "catalog publication remains separate",
                 "uploadEnabled=true",
+                "verifyChecksums=true",
                 "SourceOSKatelloUploadedArtifactVerificationReceipt",
-                "checksum-level Katello content verification",
+                "checksum-level verification",
             ],
         )
 

--- a/tests/test_verify_katello_uploaded_artifacts.py
+++ b/tests/test_verify_katello_uploaded_artifacts.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import importlib.util
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -32,6 +33,27 @@ class VerifyKatelloUploadedArtifactsTests(unittest.TestCase):
         result = module.verify(listing, ["dist/sourceos-live.iso", ""])
         self.assertEqual(result["expected"], ["sourceos-live.iso"])
         self.assertEqual(result["status"], "pass")
+
+    def test_verify_checksum_passes_when_digest_is_present(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            artifact = Path(td) / "sourceos-live.iso"
+            artifact.write_text("sourceos test artifact", encoding="utf-8")
+            digest = module.sha256_file(artifact)
+            listing = f"Name,Checksum\nsourceos-live.iso,{digest}\n"
+            result = module.verify(listing, [str(artifact)], verify_checksums=True)
+            self.assertEqual(result["status"], "pass")
+            self.assertEqual(result["missingChecksums"], [])
+            self.assertTrue(result["artifacts"][0]["checksumPresent"])
+
+    def test_verify_checksum_reports_missing_digest(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            artifact = Path(td) / "sourceos-live.iso"
+            artifact.write_text("sourceos test artifact", encoding="utf-8")
+            listing = "Name,Checksum\nsourceos-live.iso,sha256-not-the-local-file\n"
+            result = module.verify(listing, [str(artifact)], verify_checksums=True)
+            self.assertEqual(result["status"], "fail")
+            self.assertEqual(len(result["missingChecksums"]), 1)
+            self.assertFalse(result["artifacts"][0]["checksumPresent"])
 
 
 if __name__ == "__main__":

--- a/tools/verify-katello-uploaded-artifacts
+++ b/tools/verify-katello-uploaded-artifacts
@@ -1,14 +1,19 @@
 #!/usr/bin/env python3
-"""Verify expected artifact basenames appear in Hammer/Katello content listing output.
+"""Verify expected artifacts appear in Hammer/Katello file listing output.
 
-This helper is intentionally simple. It reads a text/CSV listing captured from
-Hammer and verifies that every expected artifact basename is visible somewhere in
-that listing. It emits a JSON receipt suitable for downstream evidence bundles.
+The helper verifies two levels when possible:
+- basename visibility in captured listing output
+- local SHA-256 digest visibility in captured listing output
+
+Hammer `file list` output commonly exposes file names and checksum fields. This
+helper avoids binding to one exact CSV column layout by matching expected artifact
+basenames and local SHA-256 values against the captured listing text.
 """
 
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import sys
 from pathlib import Path
@@ -19,13 +24,57 @@ def die(msg: str) -> None:
     raise SystemExit(2)
 
 
-def verify(listing_text: str, artifact_paths: list[str]) -> dict:
-    expected = [Path(path).name for path in artifact_paths if path]
-    missing = [name for name in expected if name not in listing_text]
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def verify(listing_text: str, artifact_paths: list[str], verify_checksums: bool = False) -> dict:
+    artifacts = []
+    missing_names = []
+    missing_checksums = []
+
+    for raw_path in artifact_paths:
+        if not raw_path:
+            continue
+        path = Path(raw_path)
+        name = path.name
+        name_present = name in listing_text
+        checksum = None
+        checksum_present = None
+
+        if not name_present:
+            missing_names.append(name)
+
+        if verify_checksums:
+            if not path.exists():
+                die(f"artifact not found for checksum verification: {path}")
+            checksum = sha256_file(path)
+            checksum_present = checksum in listing_text
+            if not checksum_present:
+                missing_checksums.append({"path": raw_path, "sha256": checksum})
+
+        artifacts.append(
+            {
+                "path": raw_path,
+                "basename": name,
+                "namePresent": name_present,
+                "sha256": checksum,
+                "checksumPresent": checksum_present,
+            }
+        )
+
+    status = "pass" if not missing_names and not missing_checksums else "fail"
     return {
-        "expected": expected,
-        "missing": missing,
-        "status": "pass" if not missing else "fail",
+        "artifacts": artifacts,
+        "expected": [item["basename"] for item in artifacts],
+        "missing": missing_names,
+        "missingChecksums": missing_checksums,
+        "verifyChecksums": verify_checksums,
+        "status": status,
     }
 
 
@@ -34,6 +83,7 @@ def main() -> int:
     parser.add_argument("--listing", required=True, help="Path to captured Hammer/Katello listing output")
     parser.add_argument("--artifact", action="append", default=[], help="Expected artifact path; repeatable")
     parser.add_argument("--receipt", required=True, help="Output receipt path")
+    parser.add_argument("--verify-checksums", action="store_true", help="Require local SHA-256 values to appear in listing output")
     args = parser.parse_args()
 
     listing_path = Path(args.listing)
@@ -42,12 +92,15 @@ def main() -> int:
     if not args.artifact:
         die("at least one --artifact is required")
 
-    result = verify(listing_path.read_text(encoding="utf-8", errors="replace"), args.artifact)
+    result = verify(
+        listing_path.read_text(encoding="utf-8", errors="replace"),
+        args.artifact,
+        verify_checksums=args.verify_checksums,
+    )
     receipt = {
         "apiVersion": "socios.sourceos.ai/v0",
         "kind": "SourceOSKatelloUploadedArtifactVerificationReceipt",
         "listingPath": str(listing_path),
-        "artifacts": args.artifact,
         **result,
         "receiptPath": args.receipt,
     }
@@ -55,7 +108,7 @@ def main() -> int:
     receipt_path = Path(args.receipt)
     receipt_path.parent.mkdir(parents=True, exist_ok=True)
     receipt_path.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    if result["missing"]:
+    if result["status"] != "pass":
         return 1
     return 0
 


### PR DESCRIPTION
## Summary

Adds optional checksum-level verification for the gated SourceOS Katello Hammer upload lane.

## What lands

- `tools/verify-katello-uploaded-artifacts` now supports optional local SHA-256 matching
- `tests/test_verify_katello_uploaded_artifacts.py` covers checksum pass/fail behavior
- `task-upload-sourceos-artifacts-with-hammer.yaml` adds `verifyChecksums` and passes `--verify-checksums` to the verifier when enabled
- `docs/sourceos/katello-hammer-upload-v0.md` documents the checksum gate
- `tests/test_sourceos_katello_hammer_upload_shape.py` covers the checksum gate

## Why

The merged upload lane verifies artifact-name visibility after upload. This PR adds an explicit opt-in checksum check that computes local SHA-256 values and requires those digests to appear in captured Katello file-list output.

## Safety posture

- upload remains disabled by default
- checksum verification is disabled by default
- checksum verification only runs when upload is enabled and `verifyChecksums=true`
- no credentials or secrets are stored
- SourceOS remains artifact truth
- catalog publication remains separate

## Still not included

- SourceOS release manifest mutation
- catalog publication
- automatic checksum verification without target-version validation
