### PR TITLE
sourceos: link Katello upload and lifecycle receipts

### DIFF
--- a/docs/sourceos/upload-lifecycle-link-v0.md
+++ b/docs/sourceos/upload-lifecycle-link-v0.md
@@ -1,0 +1,66 @@
+# SourceOS Upload Lifecycle Link v0
+
+Status: Draft v0
+Scope: linking Katello upload receipts to lifecycle publication/promote receipts
+
+## Purpose
+
+This document defines the seam between SourceOS artifact upload evidence and Katello lifecycle evidence.
+
+The goal is to make downstream catalog/evidence lanes able to reason over both:
+
+- artifact upload receipts
+- upload verification receipts
+- lifecycle/content-view publish/promote receipts
+
+without merging artifact truth, lifecycle truth, and catalog truth into one repo.
+
+## v0 flow
+
+```text
+SourceOS artifact upload lane
+  -> SourceOSKatelloHammerUploadReceipt
+  -> SourceOSKatelloUploadedArtifactVerificationReceipt
+  -> link-sourceos-upload-lifecycle-receipts
+  -> SourceOSUploadLifecycleLinkReceipt
+```
+
+## Receipt behavior
+
+The link task requires:
+
+- upload receipt
+- upload verification receipt
+
+The lifecycle receipt path is checked and recorded as either:
+
+- `present`
+- `missing`
+
+This keeps the task useful across local/dev runs where lifecycle publication may happen separately.
+
+## Output receipt
+
+```text
+.workstation/reports/sourceos/upload-lifecycle-link-receipt.json
+```
+
+kind:
+
+```text
+SourceOSUploadLifecycleLinkReceipt
+```
+
+## Non-goals
+
+- does not publish/promote content views
+- does not mutate SourceOS release manifests
+- does not publish to catalog
+- does not claim lifecycle correctness by itself
+
+## Follow-on work
+
+- require lifecycle receipt for qa/prod channels
+- validate content-view version ids from lifecycle receipt
+- connect link receipt to catalog publication request generation
+- add agentplane validation/run/replay refs for upload lifecycle linkage

--- a/pipelines/tekton/pipeline-sourceos-upload-lifecycle-link.yaml
+++ b/pipelines/tekton/pipeline-sourceos-upload-lifecycle-link.yaml
@@ -1,0 +1,127 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: sourceos-upload-lifecycle-link
+spec:
+  description: >-
+    Run the gated SourceOS Katello Hammer upload lane and link resulting upload
+    receipts with the Katello lifecycle receipt path.
+  params:
+    - name: contentSpecRef
+      type: string
+    - name: buildRequestRef
+      type: string
+    - name: requestedBy
+      type: string
+    - name: artifactPaths
+      type: string
+    - name: hammerRunnerImage
+      type: string
+      default: quay.io/socios/sourceos-hammer-runner:dev
+    - name: katelloServerUrl
+      type: string
+      default: https://foreman.example.com
+    - name: organization
+      type: string
+      default: SourceOS
+    - name: product
+      type: string
+      default: SourceOS Files
+    - name: repository
+      type: string
+      default: sourceos-live-iso
+    - name: uploadEnabled
+      type: string
+      default: "false"
+    - name: verifyChecksums
+      type: string
+      default: "false"
+    - name: lifecycleReceiptPath
+      type: string
+      default: /var/lib/socios/sourceos/katello-lifecycle-receipt.json
+  workspaces:
+    - name: source
+  tasks:
+    - name: materialize-sourceos-build-request
+      taskRef:
+        name: materialize-sourceos-build-request
+      workspaces:
+        - name: source
+          workspace: source
+      params:
+        - name: contentSpecRef
+          value: $(params.contentSpecRef)
+        - name: buildRequestRef
+          value: $(params.buildRequestRef)
+        - name: requestedBy
+          value: $(params.requestedBy)
+        - name: katelloProduct
+          value: $(params.product)
+        - name: katelloRepository
+          value: $(params.repository)
+
+    - name: record-sourceos-artifact-build
+      runAfter: [materialize-sourceos-build-request]
+      taskRef:
+        name: record-sourceos-artifact-build
+      workspaces:
+        - name: source
+          workspace: source
+      params:
+        - name: artifactPaths
+          value: $(params.artifactPaths)
+
+    - name: publish-sourceos-artifacts-to-katello
+      runAfter: [record-sourceos-artifact-build]
+      taskRef:
+        name: publish-sourceos-artifacts-to-katello
+      workspaces:
+        - name: source
+          workspace: source
+      params:
+        - name: katelloServerUrl
+          value: $(params.katelloServerUrl)
+        - name: organization
+          value: $(params.organization)
+        - name: product
+          value: $(params.product)
+        - name: repository
+          value: $(params.repository)
+        - name: enabled
+          value: $(params.uploadEnabled)
+
+    - name: upload-sourceos-artifacts-with-hammer
+      runAfter: [publish-sourceos-artifacts-to-katello]
+      taskRef:
+        name: upload-sourceos-artifacts-with-hammer
+      workspaces:
+        - name: source
+          workspace: source
+      params:
+        - name: hammerRunnerImage
+          value: $(params.hammerRunnerImage)
+        - name: artifactPaths
+          value: $(params.artifactPaths)
+        - name: katelloServerUrl
+          value: $(params.katelloServerUrl)
+        - name: organization
+          value: $(params.organization)
+        - name: product
+          value: $(params.product)
+        - name: repository
+          value: $(params.repository)
+        - name: enabled
+          value: $(params.uploadEnabled)
+        - name: verifyChecksums
+          value: $(params.verifyChecksums)
+
+    - name: link-sourceos-upload-lifecycle-receipts
+      runAfter: [upload-sourceos-artifacts-with-hammer]
+      taskRef:
+        name: link-sourceos-upload-lifecycle-receipts
+      workspaces:
+        - name: source
+          workspace: source
+      params:
+        - name: lifecycleReceiptPath
+          value: $(params.lifecycleReceiptPath)

--- a/pipelines/tekton/task-link-sourceos-upload-lifecycle-receipts.yaml
+++ b/pipelines/tekton/task-link-sourceos-upload-lifecycle-receipts.yaml
@@ -1,0 +1,49 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: link-sourceos-upload-lifecycle-receipts
+spec:
+  description: >-
+    Link SourceOS Katello upload receipts with lifecycle publication/promote receipts
+    into a downstream evidence receipt.
+  params:
+    - name: uploadReceiptPath
+      type: string
+      default: .workstation/reports/sourceos/katello-hammer-upload.json
+    - name: uploadVerificationReceiptPath
+      type: string
+      default: .workstation/reports/sourceos/katello-hammer-upload-verification.json
+    - name: lifecycleReceiptPath
+      type: string
+      default: /var/lib/socios/sourceos/katello-lifecycle-receipt.json
+    - name: receiptPath
+      type: string
+      default: .workstation/reports/sourceos/upload-lifecycle-link-receipt.json
+  workspaces:
+    - name: source
+      description: Workspace containing upload receipts and downstream evidence output.
+  steps:
+    - name: link
+      image: docker.io/library/busybox:latest
+      workingDir: $(workspaces.source.path)
+      script: |
+        #!/bin/sh
+        set -eu
+        test -f "$(params.uploadReceiptPath)"
+        test -f "$(params.uploadVerificationReceiptPath)"
+        lifecycle_status="present"
+        if [ ! -f "$(params.lifecycleReceiptPath)" ]; then
+          lifecycle_status="missing"
+        fi
+        mkdir -p "$(dirname "$(params.receiptPath)")"
+        cat > "$(params.receiptPath)" <<JSON
+        {
+          "apiVersion": "socios.sourceos.ai/v0",
+          "kind": "SourceOSUploadLifecycleLinkReceipt",
+          "uploadReceiptPath": "$(params.uploadReceiptPath)",
+          "uploadVerificationReceiptPath": "$(params.uploadVerificationReceiptPath)",
+          "lifecycleReceiptPath": "$(params.lifecycleReceiptPath)",
+          "lifecycleReceiptStatus": "${lifecycle_status}",
+          "receiptPath": "$(params.receiptPath)"
+        }
+        JSON

--- a/tests/test_sourceos_upload_lifecycle_link_shape.py
+++ b/tests/test_sourceos_upload_lifecycle_link_shape.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(relpath: str) -> str:
+    return (ROOT / relpath).read_text(encoding="utf-8")
+
+
+class SourceOSUploadLifecycleLinkShapeTests(unittest.TestCase):
+    def assertContainsAll(self, text: str, needles: list[str]) -> None:  # noqa: N802
+        missing = [needle for needle in needles if needle not in text]
+        self.assertEqual(missing, [], f"missing expected snippets: {missing}")
+
+    def test_upload_lifecycle_link_task_emits_receipt(self) -> None:
+        text = read("pipelines/tekton/task-link-sourceos-upload-lifecycle-receipts.yaml")
+        self.assertContainsAll(
+            text,
+            [
+                "SourceOSUploadLifecycleLinkReceipt",
+                "uploadReceiptPath",
+                "uploadVerificationReceiptPath",
+                "lifecycleReceiptPath",
+                "lifecycleReceiptStatus",
+            ],
+        )
+
+    def test_upload_lifecycle_pipeline_chains_upload_to_link(self) -> None:
+        text = read("pipelines/tekton/pipeline-sourceos-upload-lifecycle-link.yaml")
+        self.assertContainsAll(
+            text,
+            [
+                "sourceos-upload-lifecycle-link",
+                "upload-sourceos-artifacts-with-hammer",
+                "link-sourceos-upload-lifecycle-receipts",
+                "runAfter: [upload-sourceos-artifacts-with-hammer]",
+                "verifyChecksums",
+            ],
+        )
+
+    def test_upload_lifecycle_doc_preserves_boundaries(self) -> None:
+        text = read("docs/sourceos/upload-lifecycle-link-v0.md")
+        self.assertContainsAll(
+            text,
+            [
+                "does not publish/promote content views",
+                "does not mutate SourceOS release manifests",
+                "does not publish to catalog",
+                "SourceOSUploadLifecycleLinkReceipt",
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a receipt-linking seam between SourceOS Katello upload evidence and Katello lifecycle/content-view evidence.

## What lands

- `pipelines/tekton/task-link-sourceos-upload-lifecycle-receipts.yaml`
- `pipelines/tekton/pipeline-sourceos-upload-lifecycle-link.yaml`
- `docs/sourceos/upload-lifecycle-link-v0.md`
- `tests/test_sourceos_upload_lifecycle_link_shape.py`

## Why

The upload lane now emits upload and upload-verification receipts. This PR adds a downstream link receipt so catalog/evidence lanes can reference upload evidence and lifecycle publish/promote evidence together without collapsing authority boundaries.

## Safety posture

- does not publish/promote content views
- does not mutate SourceOS release manifests
- does not publish to catalog
- records lifecycle receipt presence but does not require it for all channels yet

## Follow-on

- require lifecycle receipt for qa/prod channels
- validate content-view version ids from lifecycle receipt
- connect link receipt to catalog publication request generation
