### PR TITLE
sourceos: validate upload lifecycle receipt links

### DIFF
--- a/docs/sourceos/upload-lifecycle-link-v0.md
+++ b/docs/sourceos/upload-lifecycle-link-v0.md
@@ -22,6 +22,7 @@ SourceOS artifact upload lane
   -> SourceOSKatelloHammerUploadReceipt
   -> SourceOSKatelloUploadedArtifactVerificationReceipt
   -> link-sourceos-upload-lifecycle-receipts
+  -> SourceOSLifecycleLinkValidationReceipt
   -> SourceOSUploadLifecycleLinkReceipt
 ```
 
@@ -37,9 +38,24 @@ The lifecycle receipt path is checked and recorded as either:
 - `present`
 - `missing`
 
-This keeps the task useful across local/dev runs where lifecycle publication may happen separately.
+The task also invokes `tools/validate-sourceos-lifecycle-link` to validate lifecycle/content-view evidence.
 
-## Output receipt
+## Channel gates
+
+Lifecycle receipt behavior is channel-aware:
+
+- `dev`: lifecycle receipt may be missing; validator emits warning status
+- `qa`: lifecycle receipt is required
+- `prod`: lifecycle receipt is required
+
+When a lifecycle receipt is present, it must include non-empty `latestContentViewVersions`. Each content-view version entry must include:
+
+- `id`
+- `version`
+
+## Output receipts
+
+Link receipt:
 
 ```text
 .workstation/reports/sourceos/upload-lifecycle-link-receipt.json
@@ -51,16 +67,27 @@ kind:
 SourceOSUploadLifecycleLinkReceipt
 ```
 
+Validation receipt:
+
+```text
+.workstation/reports/sourceos/lifecycle-link-validation-receipt.json
+```
+
+kind:
+
+```text
+SourceOSLifecycleLinkValidationReceipt
+```
+
 ## Non-goals
 
 - does not publish/promote content views
 - does not mutate SourceOS release manifests
 - does not publish to catalog
-- does not claim lifecycle correctness by itself
+- does not claim lifecycle correctness beyond receipt validation
 
 ## Follow-on work
 
-- require lifecycle receipt for qa/prod channels
-- validate content-view version ids from lifecycle receipt
+- validate expected content-view names against BuildRequest / ContentSpec metadata
 - connect link receipt to catalog publication request generation
 - add agentplane validation/run/replay refs for upload lifecycle linkage

--- a/pipelines/tekton/pipeline-sourceos-upload-lifecycle-link.yaml
+++ b/pipelines/tekton/pipeline-sourceos-upload-lifecycle-link.yaml
@@ -15,6 +15,9 @@ spec:
       type: string
     - name: artifactPaths
       type: string
+    - name: channel
+      type: string
+      default: dev
     - name: hammerRunnerImage
       type: string
       default: quay.io/socios/sourceos-hammer-runner:dev
@@ -55,6 +58,8 @@ spec:
           value: $(params.buildRequestRef)
         - name: requestedBy
           value: $(params.requestedBy)
+        - name: channel
+          value: $(params.channel)
         - name: katelloProduct
           value: $(params.product)
         - name: katelloRepository
@@ -123,5 +128,7 @@ spec:
         - name: source
           workspace: source
       params:
+        - name: channel
+          value: $(params.channel)
         - name: lifecycleReceiptPath
           value: $(params.lifecycleReceiptPath)

--- a/pipelines/tekton/task-link-sourceos-upload-lifecycle-receipts.yaml
+++ b/pipelines/tekton/task-link-sourceos-upload-lifecycle-receipts.yaml
@@ -7,6 +7,9 @@ spec:
     Link SourceOS Katello upload receipts with lifecycle publication/promote receipts
     into a downstream evidence receipt.
   params:
+    - name: channel
+      type: string
+      default: dev
     - name: uploadReceiptPath
       type: string
       default: .workstation/reports/sourceos/katello-hammer-upload.json
@@ -16,6 +19,9 @@ spec:
     - name: lifecycleReceiptPath
       type: string
       default: /var/lib/socios/sourceos/katello-lifecycle-receipt.json
+    - name: validationReceiptPath
+      type: string
+      default: .workstation/reports/sourceos/lifecycle-link-validation-receipt.json
     - name: receiptPath
       type: string
       default: .workstation/reports/sourceos/upload-lifecycle-link-receipt.json
@@ -24,26 +30,34 @@ spec:
       description: Workspace containing upload receipts and downstream evidence output.
   steps:
     - name: link
-      image: docker.io/library/busybox:latest
+      image: docker.io/library/python:3.12-alpine
       workingDir: $(workspaces.source.path)
       script: |
         #!/bin/sh
         set -eu
         test -f "$(params.uploadReceiptPath)"
         test -f "$(params.uploadVerificationReceiptPath)"
+        test -f ./tools/validate-sourceos-lifecycle-link
         lifecycle_status="present"
         if [ ! -f "$(params.lifecycleReceiptPath)" ]; then
           lifecycle_status="missing"
         fi
         mkdir -p "$(dirname "$(params.receiptPath)")"
+        mkdir -p "$(dirname "$(params.validationReceiptPath)")"
+        python3 ./tools/validate-sourceos-lifecycle-link \
+          --channel "$(params.channel)" \
+          --lifecycle-receipt "$(params.lifecycleReceiptPath)" \
+          --receipt "$(params.validationReceiptPath)"
         cat > "$(params.receiptPath)" <<JSON
         {
           "apiVersion": "socios.sourceos.ai/v0",
           "kind": "SourceOSUploadLifecycleLinkReceipt",
+          "channel": "$(params.channel)",
           "uploadReceiptPath": "$(params.uploadReceiptPath)",
           "uploadVerificationReceiptPath": "$(params.uploadVerificationReceiptPath)",
           "lifecycleReceiptPath": "$(params.lifecycleReceiptPath)",
           "lifecycleReceiptStatus": "${lifecycle_status}",
+          "validationReceiptPath": "$(params.validationReceiptPath)",
           "receiptPath": "$(params.receiptPath)"
         }
         JSON

--- a/tests/test_sourceos_upload_lifecycle_link_shape.py
+++ b/tests/test_sourceos_upload_lifecycle_link_shape.py
@@ -16,16 +16,20 @@ class SourceOSUploadLifecycleLinkShapeTests(unittest.TestCase):
         missing = [needle for needle in needles if needle not in text]
         self.assertEqual(missing, [], f"missing expected snippets: {missing}")
 
-    def test_upload_lifecycle_link_task_emits_receipt(self) -> None:
+    def test_upload_lifecycle_link_task_emits_receipts_and_validation(self) -> None:
         text = read("pipelines/tekton/task-link-sourceos-upload-lifecycle-receipts.yaml")
         self.assertContainsAll(
             text,
             [
                 "SourceOSUploadLifecycleLinkReceipt",
+                "SourceOSLifecycleLinkValidationReceipt",
                 "uploadReceiptPath",
                 "uploadVerificationReceiptPath",
                 "lifecycleReceiptPath",
                 "lifecycleReceiptStatus",
+                "validationReceiptPath",
+                "validate-sourceos-lifecycle-link",
+                "channel",
             ],
         )
 
@@ -39,10 +43,11 @@ class SourceOSUploadLifecycleLinkShapeTests(unittest.TestCase):
                 "link-sourceos-upload-lifecycle-receipts",
                 "runAfter: [upload-sourceos-artifacts-with-hammer]",
                 "verifyChecksums",
+                "channel",
             ],
         )
 
-    def test_upload_lifecycle_doc_preserves_boundaries(self) -> None:
+    def test_upload_lifecycle_doc_preserves_boundaries_and_channel_gates(self) -> None:
         text = read("docs/sourceos/upload-lifecycle-link-v0.md")
         self.assertContainsAll(
             text,
@@ -51,6 +56,10 @@ class SourceOSUploadLifecycleLinkShapeTests(unittest.TestCase):
                 "does not mutate SourceOS release manifests",
                 "does not publish to catalog",
                 "SourceOSUploadLifecycleLinkReceipt",
+                "SourceOSLifecycleLinkValidationReceipt",
+                "qa",
+                "prod",
+                "latestContentViewVersions",
             ],
         )
 

--- a/tests/test_validate_sourceos_lifecycle_link.py
+++ b/tests/test_validate_sourceos_lifecycle_link.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+TOOL = ROOT / "tools" / "validate-sourceos-lifecycle-link"
+
+spec = importlib.util.spec_from_file_location("validate_sourceos_lifecycle_link", TOOL)
+assert spec and spec.loader
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+VALID_LIFECYCLE = {
+    "latestContentViewVersions": {
+        "sourceos-workstation": {"id": "42", "version": "3.0"}
+    }
+}
+
+
+class ValidateSourceOSLifecycleLinkTests(unittest.TestCase):
+    def test_dev_warns_when_lifecycle_missing(self) -> None:
+        result = module.validate("dev", None)
+        self.assertEqual(result["status"], "warn")
+        self.assertFalse(result["requiresLifecycle"])
+
+    def test_qa_fails_when_lifecycle_missing(self) -> None:
+        result = module.validate("qa", None)
+        self.assertEqual(result["status"], "fail")
+        self.assertTrue(result["requiresLifecycle"])
+
+    def test_prod_fails_when_lifecycle_missing(self) -> None:
+        result = module.validate("prod", None)
+        self.assertEqual(result["status"], "fail")
+        self.assertTrue(result["requiresLifecycle"])
+
+    def test_valid_lifecycle_receipt_passes(self) -> None:
+        result = module.validate("prod", VALID_LIFECYCLE)
+        self.assertEqual(result["status"], "pass")
+        self.assertEqual(result["missingVersionEntries"], [])
+
+    def test_lifecycle_without_versions_fails(self) -> None:
+        result = module.validate("dev", {"latestContentViewVersions": {}})
+        self.assertEqual(result["status"], "fail")
+        self.assertIn("latestContentViewVersions", result["missingVersionEntries"])
+
+    def test_lifecycle_entry_missing_id_or_version_fails(self) -> None:
+        result = module.validate("qa", {"latestContentViewVersions": {"sourceos-workstation": {"id": "42"}}})
+        self.assertEqual(result["status"], "fail")
+        self.assertEqual(result["missingVersionEntries"], ["sourceos-workstation"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/validate-sourceos-lifecycle-link
+++ b/tools/validate-sourceos-lifecycle-link
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Validate SourceOS upload/lifecycle link evidence.
+
+Rules:
+- qa/prod channels require a lifecycle receipt.
+- when a lifecycle receipt is present, it must include non-empty latestContentViewVersions.
+- each latest content-view version entry must include id and version.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def die(message: str) -> None:
+    print(f"[validate-sourceos-lifecycle-link] ERROR: {message}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def load_json(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        die(f"invalid JSON in {path}: {exc}")
+
+
+def validate(channel: str, lifecycle_receipt: dict[str, Any] | None) -> dict[str, Any]:
+    requires_lifecycle = channel in {"qa", "prod"}
+    if lifecycle_receipt is None:
+        return {
+            "channel": channel,
+            "requiresLifecycle": requires_lifecycle,
+            "lifecyclePresent": False,
+            "latestContentViewVersions": {},
+            "missingVersionEntries": [],
+            "status": "fail" if requires_lifecycle else "warn",
+            "reason": "lifecycle receipt missing",
+        }
+
+    versions = lifecycle_receipt.get("latestContentViewVersions") or {}
+    missing_entries: list[str] = []
+    if not isinstance(versions, dict) or not versions:
+        return {
+            "channel": channel,
+            "requiresLifecycle": requires_lifecycle,
+            "lifecyclePresent": True,
+            "latestContentViewVersions": versions,
+            "missingVersionEntries": ["latestContentViewVersions"],
+            "status": "fail",
+            "reason": "latestContentViewVersions missing or empty",
+        }
+
+    for name, entry in versions.items():
+        if not isinstance(entry, dict) or not entry.get("id") or not entry.get("version"):
+            missing_entries.append(str(name))
+
+    return {
+        "channel": channel,
+        "requiresLifecycle": requires_lifecycle,
+        "lifecyclePresent": True,
+        "latestContentViewVersions": versions,
+        "missingVersionEntries": missing_entries,
+        "status": "pass" if not missing_entries else "fail",
+        "reason": "ok" if not missing_entries else "content-view version entries missing id/version",
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(prog="validate-sourceos-lifecycle-link")
+    parser.add_argument("--channel", required=True, choices=["dev", "qa", "prod"])
+    parser.add_argument("--lifecycle-receipt", required=True)
+    parser.add_argument("--receipt", required=True)
+    args = parser.parse_args()
+
+    lifecycle_path = Path(args.lifecycle_receipt)
+    lifecycle_receipt = load_json(lifecycle_path)
+    result = validate(args.channel, lifecycle_receipt)
+    receipt = {
+        "apiVersion": "socios.sourceos.ai/v0",
+        "kind": "SourceOSLifecycleLinkValidationReceipt",
+        "lifecycleReceiptPath": str(lifecycle_path),
+        **result,
+        "receiptPath": args.receipt,
+    }
+
+    receipt_path = Path(args.receipt)
+    receipt_path.parent.mkdir(parents=True, exist_ok=True)
+    receipt_path.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return 0 if result["status"] in {"pass", "warn"} else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds channel-aware validation for SourceOS upload/lifecycle link receipts.

## What lands

- `tools/validate-sourceos-lifecycle-link`
- `tests/test_validate_sourceos_lifecycle_link.py`
- update `task-link-sourceos-upload-lifecycle-receipts.yaml` to emit a lifecycle validation receipt
- update `pipeline-sourceos-upload-lifecycle-link.yaml` to pass channel into validation
- update `docs/sourceos/upload-lifecycle-link-v0.md`
- update `tests/test_sourceos_upload_lifecycle_link_shape.py`

## Why

The upload/lifecycle link seam now needs channel-aware validation. dev can tolerate a missing lifecycle receipt; qa/prod should require lifecycle evidence and content-view version ids.

## Safety posture

- does not publish/promote content views
- does not mutate SourceOS release manifests
- does not publish to catalog
- validates receipt structure only

## Still not included

- expected content-view name validation against BuildRequest/ContentSpec metadata
- catalog publication request generation
- agentplane validation/run/replay projection
