### PR TITLE
Add opt-in personalization orchestration contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # socios
 
-Opt-in community automation commons for SourceOS: CI/CD, update automation, training workflows, catalogs, signatures.
+Opt-in community automation commons for SourceOS: CI/CD, update automation, personalization workflows, catalogs, signatures.
 
 **OFF by default.** Enrollment requires local Proof-of-Life + signed intent.
 
@@ -21,6 +21,7 @@ Opt-in community automation commons for SourceOS: CI/CD, update automation, trai
   - mandatory dependency of SourceOS
   - public docs site
   - canonical typed-contract registry
+  - model-governance authority
 - **Semantic direction:** this repo should eventually publish an automation-focused repo descriptor that references the shared SourceOS/SociOS vocabulary from `SourceOS-Linux/sourceos-spec`.
 
 ## socios in the SourceOS ecosystem (opt-in)
@@ -29,8 +30,46 @@ Opt-in community automation commons for SourceOS: CI/CD, update automation, trai
 - CI/CD automation for updates and releases
 - policy-checked build pipelines
 - catalogs/registries with digest pins and attestations
-- optional AI automation for training/testing workflows
+- optional AI automation for evaluation and personalization workflows
 
 **SourceOS must operate without socios.** Enrollment is always explicit and gated (Proof-of-Life + signed intent).
 
 See: `docs/OPT_IN.md`
+
+## Personalization orchestration
+
+Socios may orchestrate per-user model personalization only after the user has opted in and a governance contract exists in `SocioProphet/model-governance-ledger`.
+
+Contracts and examples:
+
+```text
+schemas/personalization-orchestration.schema.json
+examples/personalization-orchestration.local-llama32.json
+tools/validate_personalization_orchestration.py
+docs/PERSONALIZATION_ORCHESTRATION.md
+```
+
+Personalization orchestration is not generic training. It is user-scoped, consented, evidence-backed workflow coordination.
+
+Required chain:
+
+```text
+signed user intent
+  -> proof-of-life
+  -> model-governance-ledger contract
+  -> Socios personalization orchestration
+  -> AgentPlane evidence
+  -> ledger receipts
+  -> model-router binding
+```
+
+Safety invariants:
+
+- off by default;
+- signed intent required;
+- proof-of-life required;
+- governance contract required;
+- whole-home ingestion denied;
+- raw app stores denied;
+- browser profiles and token stores denied;
+- promotion requires model-governance-ledger approval.

--- a/docs/PERSONALIZATION_ORCHESTRATION.md
+++ b/docs/PERSONALIZATION_ORCHESTRATION.md
@@ -1,0 +1,57 @@
+# Personalization orchestration
+
+Socios can orchestrate per-user model personalization only as an explicit opt-in workflow.
+
+This does not make Socios mandatory for SourceOS. SourceOS must continue to operate without Socios.
+
+## Required authority chain
+
+```text
+user-signed intent
+  -> proof-of-life
+  -> SocioProphet PersonalTuningContract
+  -> Socios PersonalizationOrchestration
+  -> AgentPlane evidence
+  -> model-governance-ledger receipts
+  -> model-router binding
+```
+
+No personalization job may run from a local profile alone.
+
+## Contract files
+
+```text
+schemas/personalization-orchestration.schema.json
+examples/personalization-orchestration.local-llama32.json
+tools/validate_personalization_orchestration.py
+```
+
+## Safety invariants
+
+- Socios remains off by default.
+- A signed user intent is required.
+- Proof-of-life is required.
+- A governance contract from `SocioProphet/model-governance-ledger` is required.
+- AgentPlane evidence is required.
+- Dataset lineage is required.
+- Personalization/evaluation receipts are required.
+- Promotion or revocation receipts are required.
+- Whole-home ingestion is denied.
+- Raw app stores are denied by default.
+- Browser profiles and token stores are denied by default.
+- Promotion requires model-governance-ledger approval.
+
+## Repository split
+
+| Repo | Responsibility |
+|---|---|
+| `SourceOS-Linux/sourceos-model-carry` | Local model profiles and carry-layer service references. |
+| `SocioProphet/model-governance-ledger` | Per-user consent, data boundary, evaluation, promotion, rollback, and revocation contracts. |
+| `SociOS-Linux/socios` | Opt-in orchestration of approved personalization workflows. |
+| `SocioProphet/model-router` | Runtime routing to base local model, personal adapter/model, or hosted fallback. |
+
+## Validation
+
+```bash
+python3 tools/validate_personalization_orchestration.py
+```

--- a/examples/personalization-orchestration.local-llama32.json
+++ b/examples/personalization-orchestration.local-llama32.json
@@ -1,0 +1,63 @@
+{
+  "schemaVersion": "v0.1",
+  "kind": "PersonalizationOrchestration",
+  "orchestrationId": "urn:socios:personalization-orchestration:demo-user-local-llama32",
+  "governanceContractRef": "urn:socioprophet:personal-tuning-contract:demo-user-local-llama32",
+  "signedIntentRef": "urn:socios:intent:demo-user-local-model-personalization",
+  "proofOfLifeRef": "urn:socios:proof-of-life:demo-user-local-device",
+  "subject": {
+    "userRef": "urn:socioprophet:user:demo-user",
+    "deviceRef": "urn:srcos:device:demo-laptop",
+    "workspaceRef": "urn:socioprophet:workspace:demo-workspace",
+    "tenantRef": "urn:socioprophet:tenant:demo-tenant"
+  },
+  "workflow": {
+    "mode": "dry-run",
+    "steps": [
+      "verify-signed-intent",
+      "verify-proof-of-life",
+      "verify-governance-contract",
+      "prepare-approved-sources",
+      "emit-dataset-lineage",
+      "run-evaluation-plan",
+      "write-ledger-receipts"
+    ],
+    "agentPlaneRequired": true,
+    "workstationContractRef": "urn:socios:workstation-contract:personalization-local-dry-run",
+    "jobRef": null
+  },
+  "inputs": {
+    "allowedSourceRefs": [
+      "sourceos-office://demo-workspace/output",
+      "memory-mesh://demo-user/approved-context-packs",
+      "prophet-workspace://demo-workspace/user-approved-artifacts"
+    ],
+    "deniedSourceClasses": [
+      "whole-home",
+      "browser-profiles",
+      "raw-app-stores",
+      "security-material-directories",
+      "cloud-account-material",
+      "token-stores"
+    ],
+    "baseModelRef": "urn:srcos:model-profile:local-llama32-1b",
+    "outputArtifactRef": "urn:socioprophet:model-adapter:demo-user-local-llama32-lora"
+  },
+  "policy": {
+    "offByDefault": true,
+    "requiresSignedIntent": true,
+    "requiresProofOfLife": true,
+    "localOnlyDefault": true,
+    "promotionRequiresLedgerApproval": true,
+    "allowExternalCompute": false,
+    "allowRawAppStores": false,
+    "allowWholeHomeIngestion": false
+  },
+  "evidence": {
+    "emitDatasetLineage": true,
+    "emitPersonalizationReceipt": true,
+    "emitEvalReceipt": true,
+    "emitPromotionOrRevocationReceipt": true,
+    "ledgerRef": "SocioProphet/model-governance-ledger"
+  }
+}

--- a/schemas/personalization-orchestration.schema.json
+++ b/schemas/personalization-orchestration.schema.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socios.io/automation/personalization-orchestration.schema.json",
+  "title": "PersonalizationOrchestration",
+  "description": "Opt-in Socios orchestration contract for per-user model personalization workflows. This references a valid governance contract and signed user intent.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "kind",
+    "orchestrationId",
+    "governanceContractRef",
+    "signedIntentRef",
+    "proofOfLifeRef",
+    "subject",
+    "workflow",
+    "inputs",
+    "policy",
+    "evidence"
+  ],
+  "properties": {
+    "schemaVersion": { "const": "v0.1" },
+    "kind": { "const": "PersonalizationOrchestration" },
+    "orchestrationId": { "type": "string", "pattern": "^urn:socios:personalization-orchestration:" },
+    "governanceContractRef": { "type": "string" },
+    "signedIntentRef": { "type": "string" },
+    "proofOfLifeRef": { "type": "string" },
+    "subject": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["userRef", "deviceRef", "workspaceRef"],
+      "properties": {
+        "userRef": { "type": "string" },
+        "deviceRef": { "type": "string" },
+        "workspaceRef": { "type": "string" },
+        "tenantRef": { "type": ["string", "null"] }
+      }
+    },
+    "workflow": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mode", "steps", "agentPlaneRequired"],
+      "properties": {
+        "mode": { "type": "string", "enum": ["dry-run", "prepare", "adapt", "evaluate", "promote-personal", "revoke"] },
+        "steps": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+        "agentPlaneRequired": { "type": "boolean" },
+        "workstationContractRef": { "type": ["string", "null"] },
+        "jobRef": { "type": ["string", "null"] }
+      }
+    },
+    "inputs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["allowedSourceRefs", "deniedSourceClasses", "baseModelRef"],
+      "properties": {
+        "allowedSourceRefs": { "type": "array", "items": { "type": "string" } },
+        "deniedSourceClasses": { "type": "array", "items": { "type": "string" } },
+        "baseModelRef": { "type": "string" },
+        "outputArtifactRef": { "type": ["string", "null"] }
+      }
+    },
+    "policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["offByDefault", "requiresSignedIntent", "requiresProofOfLife", "localOnlyDefault", "promotionRequiresLedgerApproval"],
+      "properties": {
+        "offByDefault": { "const": true },
+        "requiresSignedIntent": { "const": true },
+        "requiresProofOfLife": { "const": true },
+        "localOnlyDefault": { "type": "boolean" },
+        "promotionRequiresLedgerApproval": { "const": true },
+        "allowExternalCompute": { "type": "boolean", "default": false },
+        "allowRawAppStores": { "type": "boolean", "default": false },
+        "allowWholeHomeIngestion": { "type": "boolean", "default": false }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["emitDatasetLineage", "emitPersonalizationReceipt", "emitEvalReceipt", "emitPromotionOrRevocationReceipt"],
+      "properties": {
+        "emitDatasetLineage": { "type": "boolean" },
+        "emitPersonalizationReceipt": { "type": "boolean" },
+        "emitEvalReceipt": { "type": "boolean" },
+        "emitPromotionOrRevocationReceipt": { "type": "boolean" },
+        "ledgerRef": { "type": "string" }
+      }
+    }
+  }
+}

--- a/tools/validate_personalization_orchestration.py
+++ b/tools/validate_personalization_orchestration.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Validate Socios PersonalizationOrchestration examples.
+
+This bootstrap validator enforces the opt-in invariants that make Socios safe
+as the orchestration layer for per-user model personalization workflows.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "schemas/personalization-orchestration.schema.json"
+EXAMPLES = sorted((ROOT / "examples").glob("personalization-orchestration.*.json"))
+
+
+class ValidationError(Exception):
+    pass
+
+
+def load_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValidationError(f"missing file: {path.relative_to(ROOT)}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValidationError(f"invalid JSON in {path.relative_to(ROOT)}: {exc}") from exc
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValidationError(message)
+
+
+def validate_doc(path: Path, doc: dict[str, Any]) -> None:
+    require(doc.get("schemaVersion") == "v0.1", f"{path}: schemaVersion must be v0.1")
+    require(doc.get("kind") == "PersonalizationOrchestration", f"{path}: kind must be PersonalizationOrchestration")
+    require(str(doc.get("orchestrationId", "")).startswith("urn:socios:personalization-orchestration:"), f"{path}: invalid orchestrationId")
+    require(doc.get("governanceContractRef"), f"{path}: governanceContractRef is required")
+    require(doc.get("signedIntentRef"), f"{path}: signedIntentRef is required")
+    require(doc.get("proofOfLifeRef"), f"{path}: proofOfLifeRef is required")
+
+    workflow = doc.get("workflow", {})
+    require(workflow.get("agentPlaneRequired") is True, f"{path}: AgentPlane must be required for orchestration evidence")
+    require(workflow.get("steps"), f"{path}: workflow.steps must be non-empty")
+
+    inputs = doc.get("inputs", {})
+    require(inputs.get("allowedSourceRefs"), f"{path}: allowedSourceRefs must be non-empty")
+    denied = set(inputs.get("deniedSourceClasses", []))
+    for denied_class in {"whole-home", "browser-profiles", "raw-app-stores", "token-stores"}:
+        require(denied_class in denied, f"{path}: deniedSourceClasses must include {denied_class}")
+
+    policy = doc.get("policy", {})
+    require(policy.get("offByDefault") is True, f"{path}: offByDefault must be true")
+    require(policy.get("requiresSignedIntent") is True, f"{path}: signed intent is required")
+    require(policy.get("requiresProofOfLife") is True, f"{path}: proof-of-life is required")
+    require(policy.get("promotionRequiresLedgerApproval") is True, f"{path}: ledger approval is required for promotion")
+    require(policy.get("allowRawAppStores") is False, f"{path}: raw app stores must be denied by default")
+    require(policy.get("allowWholeHomeIngestion") is False, f"{path}: whole-home ingestion must be denied")
+
+    evidence = doc.get("evidence", {})
+    for key in ["emitDatasetLineage", "emitPersonalizationReceipt", "emitEvalReceipt", "emitPromotionOrRevocationReceipt"]:
+        require(evidence.get(key) is True, f"{path}: evidence.{key} must be true")
+
+
+def main() -> int:
+    load_json(SCHEMA)
+    if not EXAMPLES:
+        print("ERR: no personalization orchestration examples found", file=sys.stderr)
+        return 2
+
+    try:
+        for example in EXAMPLES:
+            doc = load_json(example)
+            validate_doc(example.relative_to(ROOT), doc)
+            print(f"ok: {example.relative_to(ROOT)}")
+    except ValidationError as exc:
+        print(f"ERR: {exc}", file=sys.stderr)
+        return 1
+
+    print("Personalization orchestration validation passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds the Socios opt-in orchestration contract for per-user model personalization workflows.

This keeps Socios in its correct role: opt-in workflow orchestration. It does not become SourceOS substrate, model governance authority, or model-router runtime policy.

## Changes

- Adds `schemas/personalization-orchestration.schema.json`.
- Adds `examples/personalization-orchestration.local-llama32.json`.
- Adds `tools/validate_personalization_orchestration.py`.
- Adds `docs/PERSONALIZATION_ORCHESTRATION.md`.
- Updates README with the opt-in personalization boundary.

## Required authority chain

```text
signed user intent
  -> proof-of-life
  -> model-governance-ledger contract
  -> Socios personalization orchestration
  -> AgentPlane evidence
  -> ledger receipts
  -> model-router binding
```

## Safety posture

- Socios remains off by default.
- Signed user intent is required.
- Proof-of-life is required.
- A governance contract from `SocioProphet/model-governance-ledger` is required.
- Whole-home ingestion is denied.
- Raw app stores are denied by default.
- Browser profiles and token stores are denied by default.
- Promotion requires model-governance-ledger approval.

## Validation

```bash
python3 tools/validate_personalization_orchestration.py
```