### PR TITLE
docs(fog): note fog catalogs are opt-in

### DIFF
--- a/catalogs/fog/README.md
+++ b/catalogs/fog/README.md
@@ -1,6 +1,6 @@
 # Fog catalogs
 
-This directory is the placeholder home for signed fog-related catalogs once a node is explicitly enrolled into `socios`.
+This directory is the placeholder home for **opt-in**, signed fog-related catalogs once a node is explicitly enrolled into `socios`.
 
 ## Intended catalog items
 


### PR DESCRIPTION
Preserves the one unique bit from the superseded `feat/fog-opt-in-hardened` branch before it is pruned: the `catalogs/fog/README.md` opt-in emphasis. The opt-in concept is already documented in `docs/FOG_OPT_IN_AUTOMATION.md`; this just carries the one-word emphasis so nothing is lost when the branch is deleted.